### PR TITLE
Adding grunt-nsp-shrinkwrap task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,6 @@ before_script:
   - sudo apt-get install libgmp3-dev
   - "mysql -e 'DROP DATABASE IF EXISTS fxa_oauth;'"
   - "mysql -e 'CREATE DATABASE fxa_oauth;'"
+
+script:
+  - grunt validate-shrinkwrap lint

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "grunt-jscs-checker": "~0.4.1",
     "grunt-mocha-test": "~0.10.2",
     "grunt-nodemon": "~0.2.1",
+    "grunt-nsp-shrinkwrap": "~0.0.3",
     "insist": "0.x",
     "jshint-stylish": "~0.2.0",
     "jwcrypto": "~0.5.0",


### PR DESCRIPTION
I think this is how we settled on doing it in fxa-{content,auth}-server projects.
We only run the validate-shrinkwrap task on Travis so it doesnt get into weird circular shrinkwrap problems. Plus, may as well quickly run lint on the Travis build while we're there.
