### PR TITLE
add summary logging

### DIFF
--- a/lib/db/index.js
+++ b/lib/db/index.js
@@ -12,8 +12,7 @@ const memory = require('./memory');
 function preClients(store) {
   var clients = config.get('clients');
   if (clients && clients.length) {
-    logger.debug('Loading pre-defined clients',
-      JSON.stringify(clients, null, 2));
+    logger.debug('Loading pre-defined clients: %:2j', clients);
     return P.all(clients.map(function(c) {
       c.id = Buffer(c.id, 'hex');
       return store.getClient(c.id).then(function(client) {
@@ -55,7 +54,7 @@ function proxy(method) {
       logger.verbose('proxying', method, [].slice.call(args));
       return driver[method].apply(driver, args);
     }).catch(function(err) {
-      logger.error(err);
+      logger.error('%s: %s', method, err);
       throw err;
     });
   };

--- a/lib/logging/json.js
+++ b/lib/logging/json.js
@@ -6,8 +6,6 @@ const util = require('util');
 
 const intel = require('intel');
 
-const HOSTNAME = require('os').hostname();
-
 function JsonFormatter(options) {
   intel.Formatter.call(this, options);
   this._format = '%O';
@@ -18,7 +16,7 @@ JsonFormatter.prototype.format = function jsonFormat(record) {
   var rec = {
     level: record.level,
     levelname: record.levelname,
-    hostname: HOSTNAME,
+    hostname: record.host,
     name: record.name,
     op: record.name,
     pid: record.pid,
@@ -27,7 +25,11 @@ JsonFormatter.prototype.format = function jsonFormat(record) {
   };
 
   if (typeof record.args[0] === 'string') {
-    rec.msg = record.message;
+    if (record.message.length > 80) {
+      rec.args = record.args;
+    } else {
+      rec.msg = record.message;
+    }
   } else {
     for (var k in record.args[0]) {
       rec[k] = record.args[0][k];

--- a/lib/logging/summary.js
+++ b/lib/logging/summary.js
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const logger = require('./').getLogger('fxa.summary');
+
+module.exports = function summary(request, response) {
+  if (request.method === 'options') {
+    return;
+  }
+  var payload = request.payload || {};
+  var query = request.query || {};
+  var params = request.params || {};
+
+  var line = {
+    code: response.isBoom ? response.output.statusCode : response.statusCode,
+    errno: response.errno || 0,
+    path: request.path,
+    agent: request.headers['user-agent'],
+    t: Date.now() - request.info.received,
+    /*jshint camelcase: false*/
+    client_id: payload.client_id || query.client_id || params.client_id
+  };
+
+  if (line.code >= 500) {
+    line.stack = response.stack;
+    logger.error(line);
+  } else {
+    logger.info(line);
+  }
+};

--- a/lib/routes/client.js
+++ b/lib/routes/client.js
@@ -16,7 +16,7 @@ const HEX_STRING = /^[0-9a-f]+$/;
 module.exports = {
   validate: {
     path: {
-      id: Joi.string()
+      client_id: Joi.string()
         .length(config.get('unique.id') * 2) // hex = bytes*2
         .regex(HEX_STRING)
         .required()
@@ -31,10 +31,10 @@ module.exports = {
   },
   handler: function requestInfoEndpoint(req, reply) {
     var params = req.params;
-    db.getClient(Buffer(params.id, 'hex')).then(function(client) {
+    db.getClient(Buffer(params.client_id, 'hex')).then(function(client) {
       if (!client) {
-        logger.debug('client:id="%s" not found', params.id);
-        throw AppError.unknownClient(params.id);
+        logger.debug('client:id="%s" not found', params.client_id);
+        throw AppError.unknownClient(params.client_id);
       }
       return client;
     }).done(function(client) {

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -21,7 +21,7 @@ module.exports = [
   },
   {
     method: 'GET',
-    path: v('/client/{id}'),
+    path: v('/client/{client_id}'),
     config: require('./routes/client')
   },
   {

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const util = require('util');
-
 const Hapi = require('hapi');
 
 const AppError = require('./error');
 const config = require('./config').root();
 const logger = require('./logging').getLogger('fxa.server');
+const summary = require('./logging/summary');
 
 exports.create = function createServer() {
   var server = Hapi.createServer(
@@ -26,20 +25,8 @@ exports.create = function createServer() {
     if (response.isBoom) {
       response = AppError.translate(response);
     }
+    summary(request, response);
     next(response);
-  });
-
-  // error response logging
-  server.on('request', function onRequest(req, evt, tags) {
-    if (tags.error && util.isError(evt.data)) {
-      var err = evt.data;
-      if (err.isBoom && err.output.statusCode < 500) {
-        // a 4xx error, so its not our fault. not an ERROR level log
-        logger.warn('%d response: %s', err.output.statusCode, err.message);
-      } else {
-        logger.error('%s', err);
-      }
-    }
   });
 
   // response logging


### PR DESCRIPTION
Example output:

``` js
{
    "level": 40,
    "levelname": "INFO",
    "name": "fxa.summary",
    "op": "fxa.summary",
    "pid": 9780,
    "hostname": "Ghul",
    "time": "2014-05-09T18:25:51.896Z",
    "v": 1,
    "code": 200,
    "errno": 0,
    "path": "/v1/client/dcdb5ae7add825d2",
    "agent": "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:32.0) Gecko/20100101 Firefox/32.0",
    "t": 7,
    "client_id": "dcdb5ae7add825d2"
}
```

@fmarier r? @kparlante look right?

fixes #42
