### PR TITLE
update awsbox browserid url

### DIFF
--- a/config/awsbox.json
+++ b/config/awsbox.json
@@ -1,8 +1,4 @@
 {
-  "browserid": {
-    "issuer": "api-accounts.dev.lcip.org",
-    "verificationUrl": "https://verifier.stage.mozaws.net/v2"
-  },
   "contentUrl": "https://oauth-ui.dev.lcip.org/oauth/",
   "db": {
     "driver": "memory"


### PR DESCRIPTION
should we just use the default production issuer? https://github.com/mozilla/fxa-oauth-server/blob/master/lib/config.js#L17

api-accounts.dev.lcip.org is dead.
