### PR TITLE
ignore unused OAuth parameters

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -14,7 +14,8 @@ exports.create = function createServer() {
     config.server.host,
     config.server.port,
     {
-      cors: true
+      cors: true,
+      validation: {stripUnknown: true}
     }
   );
 


### PR DESCRIPTION
as discussed in #79, OAuth2 conforming clients will send parameters FxA wants to ignore. I was able to complete the authorization, token, and verification steps with `requests-oauthlib` after adding this change.
