### PR TITLE
for prod/stage get a git sha from config/version.json which the rpm build will provide

### DIFF
--- a/lib/routes/root.js
+++ b/lib/routes/root.js
@@ -7,10 +7,17 @@ const fs = require('fs');
 const path = require('path');
 const util = require('util');
 
-const config = require('../config');
 const version = require('../../package.json').version;
 
-var commitHash = config.get('git.commit');
+// See if config/version.json exists (part of rpm builds)
+var commitHash = (function() {
+  var sha;
+  try {
+    sha = require('../../config/version.json');
+    sha = sha.version.hash;
+  } catch(e) { /* ignore */ }
+  return sha;
+})();
 
 module.exports = {
   handler: function index(req, reply) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-oauth-server",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Firefox Accounts OAuth2 server.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
So, I was looking at the stage builds and the value in the config file was '0.14.0-1' which was effectively the same as what we already know from package.json. It's really the git sha of the rpm that is wanted. To make things more like other services, I'll change the rpm build script to have a config/version.json and this PR will pull in that value at load time.

Also bumps the version to 0.14.1 (but maybe we should just go to 0.15.0).
