### PR TITLE
set an overall limit on request size (payload.maxBytes)

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -20,6 +20,9 @@ exports.create = function createServer() {
       debug: false,
       validation: {
         stripUnknown: true
+      },
+      payload: {
+        maxBytes: 16384
       }
     }
   );


### PR DESCRIPTION
I realize that the routes are already length limited by Joi validation rules. This just puts a limit (16384) above those to block abusive requests.
