### PR TITLE
Tweaking random indentation per jscs and eslint

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -14,6 +14,7 @@
     "requireSpaceAfterPrefixUnaryOperators": ["~"],
     "requireSpacesInConditionalExpression": true,
     "requireSpaceBeforeBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
+    "validateIndentation": 2,
     "validateQuoteMarks": "'",
     "validateJSDoc": {
         "checkParamNames": true,

--- a/lib/db/index.js
+++ b/lib/db/index.js
@@ -91,4 +91,3 @@ exports.disconnect = function disconnect() {
 exports._initialClients = function() {
   return preClients();
 };
-

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -33,31 +33,31 @@ function createSchema(conn, options) {
     ' CHARACTER SET utf8 COLLATE utf8_unicode_ci';
 
   conn.query(createDatabaseQuery, function(err) {
+    if (err) {
+      logger.error('create database', err);
+      return d.reject(err);
+    }
+
+    logger.verbose('changeUser');
+    conn.changeUser({
+      user: options.user,
+      password: options.password,
+      database: database
+    }, function(err) {
       if (err) {
-        logger.error('create database', err);
+        logger.error('changeUser', err);
         return d.reject(err);
       }
+      logger.verbose('creatingSchema');
 
-      logger.verbose('changeUser');
-      conn.changeUser({
-        user: options.user,
-        password: options.password,
-        database: database
-      }, function(err) {
+      conn.query(SCHEMA, function(err) {
         if (err) {
-          logger.error('changeUser', err);
+          logger.error('creatingSchema', err);
           return d.reject(err);
         }
-        logger.verbose('creatingSchema');
-
-        conn.query(SCHEMA, function(err) {
-          if (err) {
-            logger.error('creatingSchema', err);
-            return d.reject(err);
-          }
-          d.resolve();
-        });
+        d.resolve();
       });
+    });
   });
   return d.promise;
 }

--- a/lib/routes/authorization.js
+++ b/lib/routes/authorization.js
@@ -104,8 +104,8 @@ module.exports = {
     }).without('redirect', [
       'access_token',
       'token_type',
-      'scope']
-    ).with('access_token', 'token_type', 'scope')
+      'scope'
+    ]).with('access_token', 'token_type', 'scope')
   },
   handler: function authorizationEndpoint(req, reply) {
     var wantsGrant = req.payload.response_type === TOKEN;
@@ -153,4 +153,3 @@ module.exports = {
     .done(reply, reply);
   }
 };
-

--- a/lib/routes/client.js
+++ b/lib/routes/client.js
@@ -46,5 +46,3 @@ module.exports = {
     }, reply);
   }
 };
-
-

--- a/lib/routes/root.js
+++ b/lib/routes/root.js
@@ -24,7 +24,7 @@ module.exports = {
     function sendReply() {
       reply({
         version: version,
-        commit: commitHash,
+        commit: commitHash
       }).spaces(2);
     }
 

--- a/lib/routes/token.js
+++ b/lib/routes/token.js
@@ -95,4 +95,3 @@ module.exports = {
     .done(reply, reply);
   }
 };
-

--- a/scripts/aws.js
+++ b/scripts/aws.js
@@ -79,4 +79,3 @@ var cp = exec(cmd, function(err) {
 });
 cp.stdout.pipe(process.stdout);
 cp.stderr.pipe(process.stderr);
-

--- a/scripts/generate-client.js
+++ b/scripts/generate-client.js
@@ -22,6 +22,8 @@ function p() {
 function r(schema, cb) {
   var results = {};
   var name;
+  var prompts = Object.keys(schema);
+
   function prompt() {
     name = prompts.shift();
     var opts = schema[name];
@@ -42,7 +44,7 @@ function r(schema, cb) {
       cb(null, results);
     }
   }
-  var prompts = Object.keys(schema);
+
   prompt();
 }
 
@@ -117,4 +119,3 @@ r({
     p('');
   });
 });
-


### PR DESCRIPTION
Added `"validateIndentation": 2,` rule to .jscsrc.
Also removed extra blank lines at end of file to make ESLint less grumpy.

Current ESLint output is:

``` sh
$ eslint .

lib/db/memory.js
  62:6  error  clone is already declared in the upper scope  no-shadow

lib/db/mysql.js
  13:42  error  Use path.join() or path.resolve() instead of + to create paths  no-path-concat

lib/routes/root.js
  42:14  error  Expected error to be handled  handle-callback-err

scripts/generate-client.js
  100:49  error  Expected error to be handled  handle-callback-err

✖ 4 problems
```

... using the following `.eslintrc` file:

``` yaml
env:
  node: true

rules:
  camelcase: 0
  dot-notation: 0
  new-cap: 0
  no-alert: 0
  no-process-exit: 0
  no-underscore-dangle: 0
  no-use-before-define: [1, nofunc]
  quotes: [1, single]
  strict: 0
```
