### PR TITLE
set HSTS header for 180 days, but do not set the other HAPI security headers (e.g., x-download-options)

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -30,6 +30,16 @@ exports.create = function createServer() {
       },
       payload: {
         maxBytes: 16384
+      },
+      security: {
+        hsts: {
+          maxAge: 15552000,
+          includeSubdomains: true
+        },
+        xframe: false,
+        xss: false,
+        noOpen: false,
+        noSniff: false
       }
     }
   );

--- a/test/server.js
+++ b/test/server.js
@@ -17,6 +17,21 @@ describe('server', function() {
         assert.equal(res.statusCode, 200);
         assert.equal(res.result.version, require('../package.json').version);
         assert(res.result.commit);
+
+        // and must return an STS header 
+        var stsHeader = res.headers['strict-transport-security'];
+        assert.equal(stsHeader, 'max-age=15552000; includeSubdomains');
+
+        // but the other security builtin headers from hapi are not set
+        var other = {
+          'x-content-type-options': 1,
+          'x-download-options': 1,
+          'x-frame-options': 1,
+          'x-xss-protection': 1
+        };
+        Object.keys(res.headers).forEach(function(header) {
+          assert.ok(!other[header.toLowerCase()]);
+        });
       }).done(done, done);
     });
   });


### PR DESCRIPTION
Hi @seanmonstar. We discussed this in La-la-land, and I believe it was to set HSTS but not the rest. If I misunderstood, I can revise this PR. (Also, I'll make a similar PR for fxa-profile-server like this one if this one is agreeable).
