### PR TITLE
fixed bin/server.js for mozlog

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -4,7 +4,7 @@
 
 const config = require('../lib/config').root();
 const db = require('../lib/db');
-const logger = require('../lib/logging').getLogger('fxa.bin.server');
+const logger = require('../lib/logging')('server');
 const server = require('../lib/server').create();
 
 logger.debug('Starting with config: %:2j', config);


### PR DESCRIPTION
Starting the server was doing this:

```
fxa-oauth-server.CRITICAL: TypeError: Object function logger(name) {
  assert(app, 'mozlog.config({ app: "your-app" }) must be called first.');
  return intel.getLogger([app, name].join('.'));
} has no method 'getLogger'
  assert(app, 'mozlog.config({ app: "your-app" }) must be called first.');
  return intel.getLogger([app, name].join('.'));
} has no method 'getLogger'
    at Object.<anonymous> (/Users/dcoates/code/fxa-oauth-server/bin/server.js:7:42)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```
