### PR TITLE
fix(error): AppError uses Error.captureStackTrace

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -31,7 +31,7 @@ exports.strategy = function() {
         return reply(AppError.unauthorized('Illegal Bearer token'));
       }
 
-      token.verify(tok).done(function(details) {
+      token.verify(tok).done(function tokenFound(details) {
         if (details.scope.indexOf(exports.SCOPE_CLIENT_MANAGEMENT) !== -1) {
           logger.debug('check.whitelist');
           var blocked = !WHITELIST.some(function(re) {
@@ -50,7 +50,7 @@ exports.strategy = function() {
         reply(null, {
           credentials: details
         });
-      }, function(err) {
+      }, function noToken(err) {
         logger.debug('error', err);
         reply(AppError.unauthorized('Bearer token invalid'));
       });

--- a/lib/error.js
+++ b/lib/error.js
@@ -11,10 +11,21 @@ const DEFAULTS = {
   message: 'Unspecified error'
 };
 
+function merge(target, other) {
+  var keys = Object.keys(other || {});
+  for (var i = 0; i < keys.length; i++) {
+    target[keys[i]] = other[keys[i]];
+  }
+}
+
 function AppError(options, extra, headers) {
   this.message = options.message || DEFAULTS.message;
   this.isBoom = true;
-  this.stack = options.stack;
+  if (options.stack) {
+    this.stack = options.stack;
+  } else {
+    Error.captureStackTrace(this, AppError);
+  }
   this.errno = options.errno || DEFAULTS.errno;
   this.output = {
     statusCode: options.code || DEFAULTS.code,
@@ -27,10 +38,7 @@ function AppError(options, extra, headers) {
     },
     headers: headers || {}
   };
-  var keys = Object.keys(extra || {});
-  for (var i = 0; i < keys.length; i++) {
-    this.output.payload[keys[i]] = extra[keys[i]];
-  }
+  merge(this.output.payload, extra);
 }
 util.inherits(AppError, Error);
 


### PR DESCRIPTION
The AppError constructor accepts a `stack` property in the options,
but previously always assigned `this.stack` to it, leading to Errors
with no stack trace. This was confusing our logging infrastructure, which
tries to improve the format of the `stack` property.

Closes #164 

@vladikoff 
