### PR TITLE
use space-free tokens for mozlog (stragglers)

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -11,7 +11,7 @@ const events = require('../lib/events');
 logger.debug('config', config);
 db.ping().done(function() {
   server.start(function() {
-    logger.info('start', server.info.uri);
+    logger.info('listening', server.info.uri);
   });
   events.start();
 }, function(err) {

--- a/lib/logging/summary.js
+++ b/lib/logging/summary.js
@@ -32,8 +32,8 @@ module.exports = function summary(request, response) {
 
   if (line.code >= 500) {
     line.stack = response.stack;
-    logger.error('error', line);
+    logger.error('summary', line);
   } else {
-    logger.info('info', line);
+    logger.info('summary', line);
   }
 };


### PR DESCRIPTION
Doh! Of course, the most important line is the "logger.info('info',..." line, which we'll need as 0.26.2.

r? @seanmonstar
