### PR TITLE
feat(api): Add `action=force_auth` to GET /v1/authorization.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -260,8 +260,9 @@ content-server page.
 - `state`: A value that will be returned to the client as-is upon redirection, so that clients can verify the redirect is authentic.
 - `redirect_uri`: Optional. If supplied, a string URL of where to redirect afterwards. Must match URL from registration.
 - `scope`: Optional. A space-separated list of scopes that the user has authorized. This could be pruned by the user at the confirmation dialog.
-- `action`: Optional. If provided, should be either `signup` or `signin`. Send to improve user experience, based on whether they clicked on a Sign In or Sign Up button.
-- `email`: Optional. If provided, this email address will be pre-filled into the account form, but the user is free to change it.
+- `action`: Optional. If provided, should be `signup`, `signin`, or
+  `force_auth`. Send to improve user experience, based on whether they clicked on a Sign In or Sign Up button. `force_auth` is used to force the user specified by `email` to sign in. If `force_auth` is specified, the user is unable to modify the email address, and is unable to sign up if the user does not exist.
+- `email`: Optional if `action` is `signup` or `signin`. Required if `action` is `force_auth`. If provided, this email address will be pre-filled into the account form, but the user is free to change it.
 
 **Example:**
 

--- a/lib/routes/redirect.js
+++ b/lib/routes/redirect.js
@@ -6,11 +6,21 @@ const url = require('url');
 
 const config = require('../config');
 
+function actionToPathname(action) {
+  if (action === 'signup') {
+    return 'signup';
+  } else if (action === 'force_auth') {
+    return 'force_auth';
+  }
+
+  return 'signin';
+}
+
 module.exports = {
   handler: function redirectAuthorization(req, reply) {
     var redirect = url.parse(config.get('contentUrl'), true);
 
-    redirect.pathname += req.query.action === 'signup' ? 'signup' : 'signin';
+    redirect.pathname += actionToPathname(req.query.action);
     delete req.query.action;
 
     redirect.query = req.query;

--- a/test/api.js
+++ b/test/api.js
@@ -183,6 +183,21 @@ describe('/v1', function() {
           assert.equal(redirect.host, target.host);
         }).done(done, done);
       });
+
+      it('redirects `action=force_auth` to force_auth', function(done) {
+        var endpoint = '/authorization?action=force_auth&email=' +
+          encodeURIComponent(VEMAIL);
+        Server.api.get(endpoint)
+        .then(function(res) {
+          assert.equal(res.statusCode, 302);
+          var redirect = url.parse(res.headers.location, true);
+
+          var target = url.parse(config.get('contentUrl'), true);
+          assert.equal(redirect.pathname, target.pathname + 'force_auth');
+          assert.equal(redirect.host, target.host);
+          assert.equal(redirect.query.email, VEMAIL);
+        }).done(done, done);
+      });
     });
 
     describe('?client_id', function() {


### PR DESCRIPTION
`action=force_auth` redirects to the `/force_auth` page on the content server. On the content server, the user must sign in with the email specified by the `email` query parameter.

fixes #190 

See mozilla/fxa-content-server#1957