### PR TITLE
feat(api): allow destroying token without client_secret

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -381,7 +381,6 @@ destroy the token afterwards. A client can use this route to do so.
 #### Request Parameters
 
 - `token` - The hex string token.
-- `client_secret` - The client secret used to get the token originally.
 
 **Example:**
 
@@ -391,8 +390,7 @@ curl -v \
 -H "Content-Type: application/json" \
 "https://oauth.accounts.firefox.com/v1/destroy" \
 -d '{
-  "token": "558f9980ad5a9c279beb52123653967342f702e84d3ab34c7f80427a6a37e2c0",
-  "client_secret": "20c6882ef864d75ad1587c38f9d733c80751d2cbc8614e30202dc3d1d25301ff"
+  "token": "558f9980ad5a9c279beb52123653967342f702e84d3ab34c7f80427a6a37e2c0"
 }'
 ```
 
@@ -448,5 +446,5 @@ A valid request will return JSON with these properties:
 [redirect]: #get-v1authorization
 [authorization]: #post-v1authorization
 [token]: #post-v1token
-[delete]: #delete-v1destroy
+[delete]: #post-v1destroy
 [verify]: #post-v1verify

--- a/lib/routes/destroy.js
+++ b/lib/routes/destroy.js
@@ -1,11 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-/*jshint camelcase: false*/
 
 const Joi = require('joi');
-
-const unbuf = require('buf').unbuf.hex;
 
 const AppError = require('../error');
 const config = require('../config');
@@ -19,25 +16,17 @@ module.exports = {
       token: Joi.string()
         .length(config.get('unique.token') * 2) // hex = bytes*2
         .regex(validators.HEX_STRING)
-        .required(),
-      client_secret: validators.clientSecret
+        .required()
     }
   },
   handler: function destroyToken(req, reply) {
     var token = encrypt.hash(req.payload.token);
-    var secret = encrypt.hash(req.payload.client_secret);
 
     db.getToken(token)
     .then(function(tok) {
       if (!tok) {
         throw AppError.invalidToken();
       }
-      return db.getClient(tok.clientId);
-    }).then(function(client) {
-      if (client && (unbuf(client.secret) !== unbuf(secret))) {
-        throw AppError.incorrectSecret(client && unbuf(client.id));
-      }
-      // if client doesn't exist, but token does, then just clean up
       return db.removeToken(token);
     }).done(reply, reply);
 

--- a/test/api.js
+++ b/test/api.js
@@ -985,33 +985,13 @@ describe('/v1', function() {
         return Server.api.post({
           url: '/destroy',
           payload: {
-            token: token,
-            client_secret: secret
+            token: token
           }
         });
       }).then(function(res) {
         assert.equal(res.statusCode, 200);
         return db.getToken(encrypt.hash(token)).then(function(tok) {
           assert.equal(tok, undefined);
-        });
-      });
-    });
-
-    it('should not allow unauthorized destruction', function() {
-      var token;
-      return newToken().then(function(res) {
-        token = res.result.access_token;
-        return Server.api.post({
-          url: '/destroy',
-          payload: {
-            token: token,
-            client_secret: badSecret
-          }
-        });
-      }).then(function(res) {
-        assert.equal(res.statusCode, 400);
-        return db.getToken(encrypt.hash(token)).then(function(tok) {
-          assert(tok);
         });
       });
     });


### PR DESCRIPTION
A problem came up that I'm trying to revoke tokens created by implicit grants, so I don't have the client secret available. I looked at Google's API, and they don't require any authorization either (if you already have a token, things gon burn): https://developers.google.com/accounts/docs/OAuth2WebServer#tokenrevoke

@rfk r?