### PR TITLE
fix(api): reject requests with bad content-types

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -57,6 +57,22 @@ exports.create = function createServer() {
       delete route.config.response;
     });
   }
+
+  // require json by default
+  routes.forEach(function(route) {
+    var method = route.method.toUpperCase();
+    if (method !== 'GET' && method !== 'HEAD') {
+      if (!route.config.payload) {
+        route.config.payload = { allow: 'application/json' };
+      }
+      logger.verbose('route.payload', {
+        url: route.url,
+        method: method,
+        payload: route.config.payload
+      });
+    }
+  });
+
   server.route(routes);
 
   // hapi internal logging: server and request

--- a/test/api.js
+++ b/test/api.js
@@ -200,6 +200,21 @@ describe('/v1', function() {
       });
     });
 
+    describe('content-type', function() {
+      it('should fail if not application/json or empty', function() {
+        return Server.api.post({
+          url: '/authorization',
+          headers: {
+            'content-type': 'text/plain'
+          },
+          payload: authParams()
+        }).then(function(res) {
+          console.log(res);
+          assert.equal(res.statusCode, 415);
+        });
+      });
+    });
+
     describe('?client_id', function() {
 
       it('is required', function(done) {


### PR DESCRIPTION
Only blank and application/json are allow.

Closes #199 

r? @zaach 