### PR TITLE
fix(clients): fix server error when omitting optional fields in client registration

### DIFF
--- a/lib/routes/client/register.js
+++ b/lib/routes/client/register.js
@@ -21,7 +21,7 @@ module.exports = {
   validate: {
     payload: {
       name: Joi.string().max(256).required(),
-      image_uri: Joi.string().max(256),
+      image_uri: Joi.string().max(256).allow(''),
       redirect_uri: Joi.string().max(256).required(),
       can_grant: Joi.boolean(),
       whitelisted: Joi.boolean()
@@ -32,7 +32,7 @@ module.exports = {
       id: validators.clientId,
       secret: validators.clientSecret,
       name: Joi.string().required(),
-      image_uri: Joi.string(),
+      image_uri: Joi.string().allow(''),
       redirect_uri: Joi.string().required(),
       can_grant: Joi.boolean().required(),
       whitelisted: Joi.boolean().required()
@@ -47,8 +47,8 @@ module.exports = {
       name: payload.name,
       redirectUri: payload.redirect_uri,
       imageUri: payload.image_uri || '',
-      canGrant: payload.can_grant,
-      whitelisted: payload.whitelisted
+      canGrant: !!payload.can_grant,
+      whitelisted: !!payload.whitelisted
     };
     db.registerClient(client).then(function() {
       reply({

--- a/test/api.js
+++ b/test/api.js
@@ -810,6 +810,33 @@ describe('/v1', function() {
           assert.equal(res.statusCode, 403);
         });
       });
+
+      it('should default optional fields to sensible values', function() {
+        return Server.api.post({
+          url: '/client',
+          headers: {
+            authorization: 'Bearer ' + tok,
+          },
+          payload: {
+            name: clientName,
+            redirect_uri: clientUri
+          }
+        }).then(function(res) {
+          assert.equal(res.statusCode, 201);
+          var client = res.result;
+          assert(client.id);
+          assert(client.image_uri === '');
+          assert(client.can_grant === false);
+          assert(client.whitelisted === false);
+          return db.getClient(client.id).then(function(klient) {
+            assert.equal(klient.id.toString('hex'), client.id);
+            assert.equal(klient.name, client.name);
+            assert.equal(klient.imageUri, '');
+            assert.equal(klient.canGrant, false);
+            assert.equal(klient.whitelisted, false);
+          });
+        });
+      });
     });
 
     describe('POST /:id', function() {


### PR DESCRIPTION
This fixes some hapi response payload validation errors that could occur
when omitting optional fields in client registration:

- allow `image_uri` to be the empty string, which is the default value
- coerce `can_grant` and `whitelisted` to booleans, rather than e.g. `undefined`

fixes #203