### PR TITLE
fix(api): reject requests with invalid parameters

### DIFF
--- a/lib/routes/authorization.js
+++ b/lib/routes/authorization.js
@@ -108,17 +108,22 @@ module.exports = {
         })
     }
   },
+  payload: {
+    allow: 'application/json'
+  },
   response: {
     schema: Joi.object().keys({
       redirect: Joi.string(),
       access_token: Joi.string().regex(validators.HEX_STRING),
       token_type: Joi.string().valid('bearer'),
-      scope: Joi.string()
+      scope: Joi.string(),
+      auth_at: Joi.number()
     }).without('redirect', [
       'access_token',
       'token_type',
-      'scope'
-    ]).with('access_token', 'token_type', 'scope')
+      'scope',
+      'auth_at'
+    ]).with('access_token', 'token_type', 'scope', 'auth_at')
   },
   handler: function authorizationEndpoint(req, reply) {
     logger.debug('response_type', req.payload.response_type);

--- a/lib/server.js
+++ b/lib/server.js
@@ -26,9 +26,6 @@ exports.create = function createServer() {
     {
       cors: true,
       debug: false,
-      validation: {
-        stripUnknown: true
-      },
       payload: {
         maxBytes: 16384
       },


### PR DESCRIPTION
This keeps the leniency for the POST /v1/token endpoint, but
cactches errors for misuses of other endpoints.

Closes #210 

@washort sanity checking, this doesn't break you, does it? It's only the token endpoint that receives extra parameters?