### PR TITLE
fix(logging): use route.path in debug message, not route.url

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -65,7 +65,7 @@ exports.create = function createServer() {
         };
       }
       logger.verbose('route.payload', {
-        url: route.url,
+        path: route.path,
         method: method,
         payload: route.config.payload
       });


### PR DESCRIPTION
Minor fix I noticed when running in verbose logging. Ain't no `route.url` property.