### PR TITLE
make the clients keys mandatory in the config file

### DIFF
--- a/config/awsbox.json
+++ b/config/awsbox.json
@@ -10,7 +10,8 @@
       "name": "123done",
       "imageUri": "https://123done.dev.lcip.org/img/logo@2x.png",
       "redirectUri": "https://123done.dev.lcip.org/api/oauth",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     }
   ],
   "env": "stage",

--- a/config/dev.json
+++ b/config/dev.json
@@ -11,7 +11,8 @@
       "name": "123Done",
       "imageUri": "https://mozorg.cdn.mozilla.net/media/img/firefox/new/header-firefox.png",
       "redirectUri": "http://127.0.0.1:8080/api/oauth",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "98e6508e88680e1a",
@@ -29,7 +30,8 @@
       "canGrant": false,
       "id": "24bdbfa45cd300c5",
       "hashedSecret": "dfe56d5c816d6b7493618f6a1567cfed4aa9c25f85d59c6804631c48774ba545",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "name": "Firefox Hello DEV",
@@ -37,7 +39,8 @@
       "imageUri": "https://example2.domain/return?foo=bar",
       "id": "263ceaa5546dce83",
       "hashedSecret": "3c32099123471ffb80a7553558e6a6e8589da2235a4e081fe9d76648aa25d050",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     }
   ],
   "localRedirects": true,

--- a/config/test.json
+++ b/config/test.json
@@ -6,7 +6,8 @@
       "name": "Mocha",
       "imageUri": "https://example.domain/logo",
       "redirectUri": "https://example.domain/return?foo=bar",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "98e6508e88680e1a",
@@ -23,7 +24,8 @@
       "name": "URN",
       "imageUri": "https://example2.domain/logo",
       "redirectUri": "urn:ietf:wg:oauth:2.0:fx:webchannel",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     }
   ],
   "logging": {

--- a/lib/db/index.js
+++ b/lib/db/index.js
@@ -60,9 +60,22 @@ function preClients() {
           unbuf(encrypt.hash(c.secret)));
         process.exit(1);
       }
+
+      // ensure the required keys are present.
+      var CLIENTS_KEYS = [ 'id', 'hashedSecret', 'name', 'imageUri',
+                           'redirectUri', 'whitelisted', 'canGrant' ];
+      CLIENTS_KEYS.forEach(function(key) {
+        if (!(key in c)) {
+          var data = { key: key, name: c.name || 'unknown' };
+          logger.error('client.missing.keys', data);
+          process.exit(1);
+        }
+      });
+
       // ensure booleans are boolean and not undefined
       c.whitelisted = !!c.whitelisted;
       c.canGrant = !!c.canGrant;
+
       return exports.getClient(c.id).then(function(client) {
         if (client) {
           client = convertClientToConfigFormat(client);


### PR DESCRIPTION
In getting setup to deploy the train-30 oauth server in production today, there was delay caused by a one-character typo in the production config, a typo in 'redirecturl' (all lower case, not camelCase 'redirectUrl'). The typo didn't exist in the stage config, which made this tedious to figure out.

Anyways, the code as written should guard against and attempt to insert a NULL into a non-NULL column.

In dev, a mispelled key will show an error message like this:

  `fxa-oauth-server.db.ERROR: client.missing.keys {"key":"canGrant","name":"Firefox Hello DEV"}`

(We lose some flexibility in the config files by making keys mandatory; could consider just moving this logic to db migration files.)

NOTE: If this patch is merged, this file will need to have 'canGrant: false' added where is it missing: https://github.com/mozilla/fxa-dev/blob/master/roles/oauth/templates/config.json.j2. 