### PR TITLE
fix(travis): install libgmp3-dev so optionaldep bigint will be built for browserid-crypto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ env:
   - NODE_ENV=test DB=memory
   - NODE_ENV=test DB=mysql
 
+before_install:
+  - sudo apt-get install libgmp3-dev
+  - npm config set spin false
+
 before_script:
   - "mysql -NBe 'select version()'"
   - sudo apt-get install libgmp3-dev


### PR DESCRIPTION
I noticed, when looking at a logs of a build on travis-ci, that node-bigint was failing to compile because `gmp.h` was not available. Not a big deal, but seems better to add libgmp-dev than not. Also future-proofs for an annoying spinner more current versions of npm. 

@rfk, @seanmonstar r?