### PR TITLE
feat(clients): move client management api to a separate port

### DIFF
--- a/bin/internal.js
+++ b/bin/internal.js
@@ -4,16 +4,14 @@
 
 const config = require('../lib/config').root();
 const db = require('../lib/db');
-const logger = require('../lib/logging')('bin.server');
-const server = require('../lib/server').create();
-const events = require('../lib/events');
+const logger = require('../lib/logging')('bin.internal');
+const server = require('../lib/server/internal').create();
 
 logger.debug('config', config);
 db.ping().done(function() {
   server.start(function() {
     logger.info('listening', server.info.uri);
   });
-  events.start();
 }, function(err) {
   logger.critical('db.ping', err);
 });

--- a/lib/config.js
+++ b/lib/config.js
@@ -148,6 +148,17 @@ const conf = convict({
       default: 9010
     }
   },
+  serverInternal: {
+    host: {
+      env: 'HOST_INTERNAL',
+      default: '127.0.0.1'
+    },
+    port: {
+      env: 'PORT_INTERNAL',
+      format: 'port',
+      default: 9011
+    }
+  },
   unique: {
     clientSecret: {
       doc: 'Bytes of generated client_secrets',

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -9,7 +9,7 @@ function v(url) {
   return '/v' + version + url;
 }
 
-module.exports = [
+exports.routes = [
   {
     method: 'GET',
     path: '/',
@@ -59,27 +59,25 @@ module.exports = [
   }
 ];
 
-if (config.get('env') !== 'prod') {
-  module.exports.push.apply(module.exports, [
-    {
-      method: 'GET',
-      path: v('/clients'),
-      config: require('./routes/client/list')
-    },
-    {
-      method: 'POST',
-      path: v('/client'),
-      config: require('./routes/client/register')
-    },
-    {
-      method: 'POST',
-      path: v('/client/{client_id}'),
-      config: require('./routes/client/update')
-    },
-    {
-      method: 'DELETE',
-      path: v('/client/{client_id}'),
-      config: require('./routes/client/delete')
-    }
-  ]);
-}
+exports.clients = [
+  {
+    method: 'GET',
+    path: v('/clients'),
+    config: require('./routes/client/list')
+  },
+  {
+    method: 'POST',
+    path: v('/client'),
+    config: require('./routes/client/register')
+  },
+  {
+    method: 'POST',
+    path: v('/client/{client_id}'),
+    config: require('./routes/client/update')
+  },
+  {
+    method: 'DELETE',
+    path: v('/client/{client_id}'),
+    config: require('./routes/client/delete')
+  }
+];

--- a/lib/server/config.js
+++ b/lib/server/config.js
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = {
+  cors: true,
+  debug: false,
+  payload: {
+    maxBytes: 16384
+  },
+  security: {
+    hsts: {
+      maxAge: 15552000,
+      includeSubdomains: true
+    },
+    xframe: false,
+    xss: false,
+    noOpen: false,
+    noSniff: false
+  }
+};

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -4,12 +4,11 @@
 
 const Hapi = require('hapi');
 
-const AppError = require('./error');
-const auth = require('./auth');
-const config = require('./config').root();
-const logger = require('./logging')('server');
-const hapiLogger = require('./logging')('server.hapi');
-const summary = require('./logging/summary');
+const AppError = require('../error');
+const config = require('../config').root();
+const logger = require('../logging')('server');
+const hapiLogger = require('../logging')('server.hapi');
+const summary = require('../logging/summary');
 
 exports.create = function createServer() {
 
@@ -23,31 +22,10 @@ exports.create = function createServer() {
   var server = Hapi.createServer(
     config.server.host,
     config.server.port,
-    {
-      cors: true,
-      debug: false,
-      payload: {
-        maxBytes: 16384
-      },
-      security: {
-        hsts: {
-          maxAge: 15552000,
-          includeSubdomains: true
-        },
-        xframe: false,
-        xss: false,
-        noOpen: false,
-        noSniff: false
-      }
-    }
+    require('./config')
   );
 
-
-
-  server.auth.scheme(auth.AUTH_SCHEME, auth.strategy);
-  server.auth.strategy(auth.AUTH_STRATEGY, auth.AUTH_SCHEME);
-
-  var routes = require('./routing');
+  var routes = require('../routing').routes;
   if (isProd) {
     logger.info('prod', 'Disabling response schema validation');
     routes.forEach(function(route) {
@@ -55,7 +33,7 @@ exports.create = function createServer() {
     });
   }
 
-  // require json by default
+  // default to stricter content-type
   routes.forEach(function(route) {
     var method = route.method.toUpperCase();
     if (method !== 'GET' && method !== 'HEAD') {

--- a/lib/server/internal.js
+++ b/lib/server/internal.js
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const Hapi = require('hapi');
+
+const AppError = require('../error');
+const auth = require('../auth');
+const config = require('../config').root();
+const logger = require('../logging')('server.clients');
+const hapiLogger = require('../logging')('server.hapi');
+const summary = require('../logging/summary');
+
+exports.create = function createServer() {
+  var isProd = config.env === 'prod';
+  var server = Hapi.createServer(
+    config.serverInternal.host,
+    config.serverInternal.port,
+    require('./config')
+  );
+
+
+
+  server.auth.scheme(auth.AUTH_SCHEME, auth.strategy);
+  server.auth.strategy(auth.AUTH_STRATEGY, auth.AUTH_SCHEME);
+
+  var routes = require('../routing').clients;
+  if (isProd) {
+    logger.info('prod', 'Disabling response schema validation');
+    routes.forEach(function(route) {
+      delete route.config.response;
+    });
+  }
+
+  // default to stricter content-type
+  routes.forEach(function(route) {
+    var method = route.method.toUpperCase();
+    if (method !== 'GET' && method !== 'HEAD') {
+      if (!route.config.payload) {
+        route.config.payload = {
+          allow: ['application/json', 'application/x-www-form-urlencoded']
+        };
+      }
+      logger.verbose('route.payload', {
+        path: route.path,
+        method: method,
+        payload: route.config.payload
+      });
+    }
+  });
+
+  server.route(routes);
+
+  // hapi internal logging: server and request
+  server.on('log', function onServerLog(ev, tags) {
+    if (tags.error && tags.implementation) {
+      hapiLogger.critical('error.uncaught', { tags: ev.tags, error: ev.data });
+    }
+  });
+
+  server.on('request', function onRequestLog(req, ev, tags) {
+    if (tags.error && tags.implementation) {
+      hapiLogger.critical('error.uncaught', { tags: ev.tags, error: ev.data });
+    }
+  });
+
+  server.ext('onPreResponse', function onPreResponse(request, next) {
+    var response = request.response;
+    if (response.isBoom) {
+      response = AppError.translate(response);
+    }
+    summary(request, response);
+    next(response);
+  });
+
+  return server;
+};

--- a/test/api.js
+++ b/test/api.js
@@ -746,244 +746,257 @@ describe('/v1', function() {
       });
     });
 
-    describe('GET /clients', function() {
-      it('should require authorization', function() {
-        return Server.api.get({
-          url: '/clients'
-        }).then(function(res) {
-          assert.equal(res.statusCode, 401);
+    describe('client management api', function() {
+      it('should not be available on main server', function(){
+        return P.all([
+          Server.api.get('/clients'),
+          Server.api.post('/client'),
+          Server.api.post('/client/' + clientId),
+          Server.api.delete('/client/' + clientId)
+        ]).map(function(res) {
+          assert.equal(res.statusCode, 404);
         });
       });
 
-      it('should check the whitelist', function() {
-        return Server.api.get({
-          url: '/clients',
-          headers: {
-            authorization: 'Bearer ' + badTok
-          }
-        }).then(function(res) {
-          assert.equal(res.statusCode, 403);
-        });
-      });
-
-      it('should return a list of clients', function() {
-        return Server.api.get({
-          url: '/clients',
-          headers: {
-            authorization: 'Bearer ' + tok
-          }
-        }).then(function(res) {
-          assert.equal(res.statusCode, 200);
-          return db.getClients().then(function(clients) {
-            assert.equal(res.result.clients.length, clients.length);
+      describe('GET /clients', function() {
+        it('should require authorization', function() {
+          return Server.internal.api.get({
+            url: '/clients'
+          }).then(function(res) {
+            assert.equal(res.statusCode, 401);
           });
         });
-      });
-    });
 
-    describe('POST', function() {
-      it('should register a client', function() {
-        return Server.api.post({
-          url: '/client',
-          headers: {
-            authorization: 'Bearer ' + tok,
-          },
-          payload: {
-            name: clientName,
-            redirect_uri: clientUri,
-            image_uri: clientUri,
-            can_grant: true,
-            whitelisted: true
-          }
-        }).then(function(res) {
-          assert.equal(res.statusCode, 201);
-          var client = res.result;
-          assert(client.id);
-          return db.getClient(client.id).then(function(klient) {
-            assert.equal(klient.id.toString('hex'), client.id);
-            assert.equal(klient.name, client.name);
-            assert.equal(klient.redirectUri, client.redirect_uri);
-            assert.equal(klient.canGrant, true);
-            assert.equal(klient.whitelisted, true);
+        it('should check the whitelist', function() {
+          return Server.internal.api.get({
+            url: '/clients',
+            headers: {
+              authorization: 'Bearer ' + badTok
+            }
+          }).then(function(res) {
+            assert.equal(res.statusCode, 403);
+          });
+        });
+
+        it('should return a list of clients', function() {
+          return Server.internal.api.get({
+            url: '/clients',
+            headers: {
+              authorization: 'Bearer ' + tok
+            }
+          }).then(function(res) {
+            assert.equal(res.statusCode, 200);
+            return db.getClients().then(function(clients) {
+              assert.equal(res.result.clients.length, clients.length);
+            });
           });
         });
       });
 
-      it('should require authorization', function() {
-        return Server.api.post({
-          url: '/client',
-          payload: {
-            name: 'dont matter'
-          }
-        }).then(function(res) {
-          assert.equal(res.statusCode, 401);
-        });
-      });
-
-      it('should check the whitelist', function() {
-        return Server.api.post({
-          url: '/client',
-          headers: {
-            authorization: 'Bearer ' + badTok
-          }
-        }).then(function(res) {
-          assert.equal(res.statusCode, 403);
-        });
-      });
-
-      it('should default optional fields to sensible values', function() {
-        return Server.api.post({
-          url: '/client',
-          headers: {
-            authorization: 'Bearer ' + tok,
-          },
-          payload: {
-            name: clientName,
-            redirect_uri: clientUri
-          }
-        }).then(function(res) {
-          assert.equal(res.statusCode, 201);
-          var client = res.result;
-          assert(client.id);
-          assert(client.image_uri === '');
-          assert(client.can_grant === false);
-          assert(client.whitelisted === false);
-          return db.getClient(client.id).then(function(klient) {
-            assert.equal(klient.id.toString('hex'), client.id);
-            assert.equal(klient.name, client.name);
-            assert.equal(klient.imageUri, '');
-            assert.equal(klient.canGrant, false);
-            assert.equal(klient.whitelisted, false);
-          });
-        });
-      });
-    });
-
-    describe('POST /:id', function() {
-      var id = unique.id();
-      it('should update the client', function() {
-        var secret = unique.secret();
-        var imageUri = 'https://example.foo.domain/logo.png';
-        var client = {
-          name: 'test/api/update',
-          id: id,
-          hashedSecret: encrypt.hash(secret),
-          redirectUri: 'https://example.domain',
-          imageUri: imageUri,
-          whitelisted: true
-        };
-        return db.registerClient(client).then(function() {
-          return Server.api.post({
-            url: '/client/' + id.toString('hex'),
+      describe('POST', function() {
+        it('should register a client', function() {
+          return Server.internal.api.post({
+            url: '/client',
             headers: {
               authorization: 'Bearer ' + tok,
             },
             payload: {
-              name: 'updated',
-              redirect_uri: clientUri
+              name: clientName,
+              redirect_uri: clientUri,
+              image_uri: clientUri,
+              can_grant: true,
+              whitelisted: true
             }
+          }).then(function(res) {
+            assert.equal(res.statusCode, 201);
+            var client = res.result;
+            assert(client.id);
+            return db.getClient(client.id).then(function(klient) {
+              assert.equal(klient.id.toString('hex'), client.id);
+              assert.equal(klient.name, client.name);
+              assert.equal(klient.redirectUri, client.redirect_uri);
+              assert.equal(klient.canGrant, true);
+              assert.equal(klient.whitelisted, true);
+            });
           });
-        }).then(function(res) {
-          assert.equal(res.statusCode, 200);
-          assert.equal(res.payload, '{}');
-          return db.getClient(id);
-        }).then(function(klient) {
-          assert.equal(klient.name, 'updated');
-          assert.equal(klient.redirectUri, clientUri);
-          assert.equal(klient.imageUri, imageUri);
-          assert.equal(klient.whitelisted, true);
-          assert.equal(klient.canGrant, false);
         });
-      });
 
-      it('should forbid unknown properties', function() {
-        return Server.api.post({
-          url: '/client/' + id.toString('hex'),
-          headers: {
-            authorization: 'Bearer ' + tok
-          },
-          payload: {
-            foo: 'bar'
-          }
-        }).then(function(res) {
-          assert.equal(res.statusCode, 400);
+        it('should require authorization', function() {
+          return Server.internal.api.post({
+            url: '/client',
+            payload: {
+              name: 'dont matter'
+            }
+          }).then(function(res) {
+            assert.equal(res.statusCode, 401);
+          });
         });
-      });
 
-      it('should require authorization', function() {
-        return Server.api.post({
-          url: '/client/' + id.toString('hex'),
-          payload: {
-            name: 'dont matter'
-          }
-        }).then(function(res) {
-          assert.equal(res.statusCode, 401);
+        it('should check the whitelist', function() {
+          return Server.internal.api.post({
+            url: '/client',
+            headers: {
+              authorization: 'Bearer ' + badTok
+            }
+          }).then(function(res) {
+            assert.equal(res.statusCode, 403);
+          });
         });
-      });
 
-      it('should check the whitelist', function() {
-        return Server.api.post({
-          url: '/client/' + id.toString('hex'),
-          headers: {
-            authorization: 'Bearer ' + badTok
-          }
-        }).then(function(res) {
-          assert.equal(res.statusCode, 403);
-        });
-      });
-    });
-
-    describe('DELETE /:id', function() {
-      var id = unique.id();
-      it('should delete the client', function() {
-        var secret = unique.secret();
-        var client = {
-          name: 'test/api/delete',
-          id: id,
-          hashedSecret: encrypt.hash(secret),
-          redirectUri: clientUri,
-          imageUri: clientUri,
-          whitelisted: true
-        };
-        return db.registerClient(client).then(function() {
-          return Server.api.delete({
-            url: '/client/' + id.toString('hex'),
+        it('should default optional fields to sensible values', function() {
+          return Server.internal.api.post({
+            url: '/client',
             headers: {
               authorization: 'Bearer ' + tok,
+            },
+            payload: {
+              name: clientName,
+              redirect_uri: clientUri
             }
+          }).then(function(res) {
+            assert.equal(res.statusCode, 201);
+            var client = res.result;
+            assert(client.id);
+            assert(client.image_uri === '');
+            assert(client.can_grant === false);
+            assert(client.whitelisted === false);
+            return db.getClient(client.id).then(function(klient) {
+              assert.equal(klient.id.toString('hex'), client.id);
+              assert.equal(klient.name, client.name);
+              assert.equal(klient.imageUri, '');
+              assert.equal(klient.canGrant, false);
+              assert.equal(klient.whitelisted, false);
+            });
           });
-        }).then(function(res) {
-          assert.equal(res.statusCode, 204);
-          return db.getClient(id);
-        }).then(function(client) {
-          assert.equal(client, undefined);
         });
       });
 
-      it('should require authorization', function() {
-        return Server.api.delete({
-          url: '/client/' + id.toString('hex'),
-          payload: {
-            name: 'dont matter'
-          }
-        }).then(function(res) {
-          assert.equal(res.statusCode, 401);
+      describe('POST /:id', function() {
+        var id = unique.id();
+        it('should update the client', function() {
+          var secret = unique.secret();
+          var imageUri = 'https://example.foo.domain/logo.png';
+          var client = {
+            name: 'test/api/update',
+            id: id,
+            hashedSecret: encrypt.hash(secret),
+            redirectUri: 'https://example.domain',
+            imageUri: imageUri,
+            whitelisted: true
+          };
+          return db.registerClient(client).then(function() {
+            return Server.internal.api.post({
+              url: '/client/' + id.toString('hex'),
+              headers: {
+                authorization: 'Bearer ' + tok,
+              },
+              payload: {
+                name: 'updated',
+                redirect_uri: clientUri
+              }
+            });
+          }).then(function(res) {
+            assert.equal(res.statusCode, 200);
+            assert.equal(res.payload, '{}');
+            return db.getClient(id);
+          }).then(function(klient) {
+            assert.equal(klient.name, 'updated');
+            assert.equal(klient.redirectUri, clientUri);
+            assert.equal(klient.imageUri, imageUri);
+            assert.equal(klient.whitelisted, true);
+            assert.equal(klient.canGrant, false);
+          });
+        });
+
+        it('should forbid unknown properties', function() {
+          return Server.internal.api.post({
+            url: '/client/' + id.toString('hex'),
+            headers: {
+              authorization: 'Bearer ' + tok
+            },
+            payload: {
+              foo: 'bar'
+            }
+          }).then(function(res) {
+            assert.equal(res.statusCode, 400);
+          });
+        });
+
+        it('should require authorization', function() {
+          return Server.internal.api.post({
+            url: '/client/' + id.toString('hex'),
+            payload: {
+              name: 'dont matter'
+            }
+          }).then(function(res) {
+            assert.equal(res.statusCode, 401);
+          });
+        });
+
+        it('should check the whitelist', function() {
+          return Server.internal.api.post({
+            url: '/client/' + id.toString('hex'),
+            headers: {
+              authorization: 'Bearer ' + badTok
+            }
+          }).then(function(res) {
+            assert.equal(res.statusCode, 403);
+          });
         });
       });
 
-      it('should check the whitelist', function() {
-        return Server.api.delete({
-          url: '/client/' + id.toString('hex'),
-          headers: {
-            authorization: 'Bearer ' + badTok
-          }
-        }).then(function(res) {
-          assert.equal(res.statusCode, 403);
+      describe('DELETE /:id', function() {
+        var id = unique.id();
+        it('should delete the client', function() {
+          var secret = unique.secret();
+          var client = {
+            name: 'test/api/delete',
+            id: id,
+            hashedSecret: encrypt.hash(secret),
+            redirectUri: clientUri,
+            imageUri: clientUri,
+            whitelisted: true
+          };
+          return db.registerClient(client).then(function() {
+            return Server.internal.api.delete({
+              url: '/client/' + id.toString('hex'),
+              headers: {
+                authorization: 'Bearer ' + tok,
+              }
+            });
+          }).then(function(res) {
+            assert.equal(res.statusCode, 204);
+            return db.getClient(id);
+          }).then(function(client) {
+            assert.equal(client, undefined);
+          });
+        });
+
+        it('should require authorization', function() {
+          return Server.internal.api.delete({
+            url: '/client/' + id.toString('hex'),
+            payload: {
+              name: 'dont matter'
+            }
+          }).then(function(res) {
+            assert.equal(res.statusCode, 401);
+          });
+        });
+
+        it('should check the whitelist', function() {
+          return Server.internal.api.delete({
+            url: '/client/' + id.toString('hex'),
+            headers: {
+              authorization: 'Bearer ' + badTok
+            }
+          }).then(function(res) {
+            assert.equal(res.statusCode, 403);
+          });
         });
       });
     });
-  });
 
+  });
   describe('/verify', function() {
 
     describe('unknown token', function() {

--- a/test/lib/server.js
+++ b/test/lib/server.js
@@ -4,47 +4,54 @@
 
 const P = require('../../lib/promise');
 const Server = require('../../lib/server');
+const Internal = require('../../lib/server/internal');
 const version = require('../../lib/config').get('api.version');
 
-var server = Server.create();
-function request(options) {
-  var deferred = P.defer();
-  server.inject(options, deferred.resolve.bind(deferred));
-  return deferred.promise;
-}
-
-function opts(options) {
-  if (typeof options === 'string') {
-    options = { url: options };
+function wrapServer(server) {
+  var wrap = {};
+  function request(options) {
+    var deferred = P.defer();
+    server.inject(options, deferred.resolve.bind(deferred));
+    return deferred.promise;
   }
-  return options;
+
+  function opts(options) {
+    if (typeof options === 'string') {
+      options = { url: options };
+    }
+    return options;
+  }
+
+  wrap.post = function post(options) {
+    options = opts(options);
+    options.method = 'POST';
+    return request(options);
+  };
+
+  wrap.get = function get(options) {
+    options = opts(options);
+    options.method = 'GET';
+    return request(options);
+  };
+
+  wrap.delete = function _delete(options) {
+    options = opts(options);
+    options.method = 'DELETE';
+    return request(options);
+  };
+
+  var api = {};
+  Object.keys(wrap).forEach(function(key) {
+    api[key] = function api(options) {
+      options = opts(options);
+      options.url = '/v' + version + options.url;
+      return wrap[key](options);
+    };
+  });
+
+  wrap.api = api;
+  return wrap;
 }
 
-exports.post = function post(options) {
-  options = opts(options);
-  options.method = 'POST';
-  return request(options);
-};
-
-exports.get = function get(options) {
-  options = opts(options);
-  options.method = 'GET';
-  return request(options);
-};
-
-exports.delete = function _delete(options) {
-  options = opts(options);
-  options.method = 'DELETE';
-  return request(options);
-};
-
-var api = {};
-Object.keys(exports).forEach(function(key) {
-  api[key] = function api(options) {
-    options = opts(options);
-    options.url = '/v' + version + options.url;
-    return exports[key](options);
-  };
-});
-
-exports.api = api;
+module.exports = wrapServer(Server.create());
+module.exports.internal = wrapServer(Internal.create());


### PR DESCRIPTION
This will allow the management APIs to be turned on in "production", but using a port that is not publicly accessible.

/cc @ckolos @ckarlof 