### PR TITLE
feat(auth): redirect to content-server oauth root by default

### DIFF
--- a/lib/routes/redirect.js
+++ b/lib/routes/redirect.js
@@ -11,9 +11,11 @@ function actionToPathname(action) {
     return 'signup';
   } else if (action === 'force_auth') {
     return 'force_auth';
+  } else if (action === 'signin') {
+    return 'signin';
   }
 
-  return 'signin';
+  return '';
 }
 
 module.exports = {

--- a/test/api.js
+++ b/test/api.js
@@ -174,14 +174,32 @@ describe('/v1', function() {
         }).done(done, done);
       });
 
-      it('redirects with signin action by default', function(done) {
+      it('redirects `action=signin` to signin', function(done) {
+        Server.api
+        .get('/authorization?client_id=123&state=321&scope=1&action=signin&a=b')
+        .then(function(res) {
+          assert.equal(res.statusCode, 302);
+          var redirect = url.parse(res.headers.location, true);
+
+          assert.equal(redirect.query.client_id, '123');
+          assert.equal(redirect.query.state, '321');
+          assert.equal(redirect.query.scope, '1');
+          // unknown query params are forwarded
+          assert.equal(redirect.query.a, 'b');
+          var target = url.parse(config.get('contentUrl'), true);
+          assert.equal(redirect.pathname, target.pathname + 'signin');
+          assert.equal(redirect.host, target.host);
+        }).done(done, done);
+      });
+
+      it('redirects no action to contentUrl root', function(done) {
         Server.api.get('/authorization?client_id=123&state=321&scope=1')
         .then(function(res) {
           assert.equal(res.statusCode, 302);
           var redirect = url.parse(res.headers.location, true);
 
           var target = url.parse(config.get('contentUrl'), true);
-          assert.equal(redirect.pathname, target.pathname + 'signin');
+          assert.equal(redirect.pathname, target.pathname);
           assert.equal(redirect.host, target.host);
         }).done(done, done);
       });


### PR DESCRIPTION
Fixes #245.

Depends on implementation of https://github.com/mozilla/fxa-content-server/issues/2344