### PR TITLE
fix(api): ensure /destroy endpoint returns an empty object in response body

### DIFF
--- a/lib/routes/destroy.js
+++ b/lib/routes/destroy.js
@@ -28,7 +28,8 @@ module.exports = {
         throw AppError.invalidToken();
       }
       return db.removeToken(token);
-    }).done(reply, reply);
-
+    }).done(function() {
+      reply({});
+    }, reply);
   }
 };

--- a/test/api.js
+++ b/test/api.js
@@ -1441,6 +1441,7 @@ describe('/v1', function() {
         });
       }).then(function(res) {
         assert.equal(res.statusCode, 200);
+        assert.deepEqual(res.result, {});
         return db.getToken(encrypt.hash(token)).then(function(tok) {
           assert.equal(tok, undefined);
         });


### PR DESCRIPTION
Fixes #236.  (And with apologies to @chilts for stealing his bug; I've been starting at oauth server response bodies for that last hour and this was really starting to grate on me...)