### PR TITLE
WIP: Add token management endpoints

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -64,6 +64,9 @@ The currently-defined error responses are:
   - [DELETE /v1/client/:id][client-delete]
 - Developers
   - [POST /v1/developer/activate][developer-activate]
+- Users
+  - [GET /v1/user/tokens][user-tokens]
+  - [DELETE /v1/user/token/:id][user-token-delete]
 - [POST /v1/verify][verify]
 
 ### GET /v1/client/:id
@@ -469,6 +472,66 @@ A valid request will return JSON with these properties:
 }
 ```
 
+### GET /v1/user/tokens
+
+Gets a list of active tokens for a user. The `token_id` field of each token
+record is an opaque identifier that can be used to revoke the token.
+
+**Required scope:** `oauth:tokens`
+
+#### Request Parameters
+
+**Example:**
+
+```sh
+curl -v \
+-H "Authorization: Bearer 558f9980ad5a9c279beb52123653967342f702e84d3ab34c7f80427a6a37e2c0" \
+"https://oauth.accounts.firefox.com/v1/user/tokens"
+```
+
+#### Response
+
+A valid response will have a 200 status code and a list of token records:
+
+```json
+{
+  "tokens": [{
+    "token_id": "92784bc8b18985ae03a015bff9e6b6322e9a74a9673fa08bada418e4fb4e2f6a",
+    "client_id": "bc57cc3f2cfeb8c9",
+    "token_type": "bearer",
+    "scope": "profile:uid",
+    "created_at": 1432919962142
+  }, {
+    "token_id": "b0e7d5503130c72ba74ca238175f35609a65b8d441c7f09ac2cac43d469167f6",
+    "client_id": "77cae338e95db56c",
+    "token_type": "bearer",
+    "scope": "profile oauth:tokens",
+    "created_at": 1432920262142
+  }]
+}
+```
+
+### DELETE /v1/user/token/:id
+
+Revokes a token for an user.
+
+**Required scope:** `oauth:tokens`
+
+#### Request Parameters
+
+**Example:**
+
+```sh
+curl -v \
+-X DELETE \
+-H "Authorization: Bearer 558f9980ad5a9c279beb52123653967342f702e84d3ab34c7f80427a6a37e2c0" \
+"https://oauth.accounts.firefox.com/v1/user/token/92784bc8b18985ae03a015bff9e6b6322e9a74a9673fa08bada418e4fb4e2f6a"
+```
+
+#### Response
+
+A valid response will have a 204 response code and an empty body.
+
 [client]: #get-v1clientid
 [register]: #post-v1clientregister
 [clients]: #get-v1clients
@@ -480,3 +543,5 @@ A valid request will return JSON with these properties:
 [delete]: #post-v1destroy
 [verify]: #post-v1verify
 [developer-activate]: #post-v1developeractivate
+[user-tokens]: #get-v1usertokens
+[user-token-delete]: #delete-usertokenid

--- a/docs/api.md
+++ b/docs/api.md
@@ -460,6 +460,7 @@ A valid request will return JSON with these properties:
 - `client_id`: The client_id of the respective client.
 - `scope`: An array of scopes allowed for this token.
 - `email`: The email of the respective user.
+- `created_at`: The token creation time in milliseconds since Epoch.
 
 **Example:**
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -474,8 +474,8 @@ A valid request will return JSON with these properties:
 
 ### GET /v1/user/tokens
 
-Gets a list of active tokens for a user. The `token_id` field of each token
-record is an opaque identifier that can be used to revoke the token.
+Gets a list of active tokens for a user. The `id` field of each token record is
+an opaque identifier that can be used to revoke the token.
 
 **Required scope:** `oauth:tokens`
 
@@ -496,13 +496,13 @@ A valid response will have a 200 status code and a list of token records:
 ```json
 {
   "tokens": [{
-    "token_id": "92784bc8b18985ae03a015bff9e6b6322e9a74a9673fa08bada418e4fb4e2f6a",
+    "id": "92784bc8b18985ae03a015bff9e6b6322e9a74a9673fa08bada418e4fb4e2f6a",
     "client_id": "bc57cc3f2cfeb8c9",
     "token_type": "bearer",
     "scope": "profile:uid",
     "created_at": 1432919962142
   }, {
-    "token_id": "b0e7d5503130c72ba74ca238175f35609a65b8d441c7f09ac2cac43d469167f6",
+    "id": "b0e7d5503130c72ba74ca238175f35609a65b8d441c7f09ac2cac43d469167f6",
     "client_id": "77cae338e95db56c",
     "token_type": "bearer",
     "scope": "profile oauth:tokens",

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -16,6 +16,19 @@ exports.AUTH_STRATEGY = 'dogfood';
 exports.AUTH_SCHEME = 'bearer';
 
 exports.SCOPE_CLIENT_MANAGEMENT = 'oauth';
+exports.SCOPE_TOKEN_MANAGEMENT = 'oauth:tokens';
+
+function canManageClients(scopes) {
+  for (var i = 0, len = scopes.length; i < len; i++) {
+    var scope = scopes[i];
+    if (scope === exports.SCOPE_CLIENT_MANAGEMENT ||
+      scope.lastIndexOf(exports.SCOPE_CLIENT_MANAGEMENT + ':', 0) === 0) {
+
+      return true;
+    }
+  }
+  return false;
+}
 
 exports.strategy = function() {
   return {
@@ -32,7 +45,7 @@ exports.strategy = function() {
       }
 
       token.verify(tok).done(function tokenFound(details) {
-        if (details.scope.indexOf(exports.SCOPE_CLIENT_MANAGEMENT) !== -1) {
+        if (canManageClients(details.scope)) {
           logger.debug('check.whitelist');
           var blocked = !WHITELIST.some(function(re) {
             return re.test(details.email);

--- a/lib/db/memory.js
+++ b/lib/db/memory.js
@@ -218,8 +218,12 @@ MemoryStore.prototype = {
     return P.resolve(this.tokens[unbuf(token)]);
   },
   removeToken: function removeToken(id) {
-    delete this.tokens[unbuf(id)];
-    return P.resolve();
+    var tokenId = unbuf(id);
+    if (!this.tokens[tokenId]) {
+      return P.resolve(false);
+    }
+    delete this.tokens[tokenId];
+    return P.resolve(true);
   },
   getEncodingInfo: function getEncodingInfo() {
     console.warn('getEncodingInfo has no meaning with memory implementation');

--- a/lib/db/memory.js
+++ b/lib/db/memory.js
@@ -225,6 +225,16 @@ MemoryStore.prototype = {
     console.warn('getEncodingInfo has no meaning with memory implementation');
     return P.resolve({});
   },
+  getUserTokens: function getUserTokens(userId) {
+    var tokens = [];
+    Object.keys(this.tokens).forEach(function(key) {
+      var entry = this.tokens[key];
+      if (unbuf(entry.userId) === userId) {
+        tokens.push(entry);
+      }
+    }, this);
+    return P.resolve(tokens);
+  },
   removeUser: function removeUser(userId) {
     deleteByUserId(this.tokens, userId);
     deleteByUserId(this.codes, userId);

--- a/lib/db/mysql/index.js
+++ b/lib/db/mysql/index.js
@@ -380,7 +380,9 @@ MysqlStore.prototype = {
   },
 
   removeToken: function removeToken(id) {
-    return this._write(QUERY_TOKEN_DELETE, [buf(id)]);
+    return this._write(QUERY_TOKEN_DELETE, [buf(id)]).then(function(result) {
+      return result.affectedRows > 0;
+    });
   },
 
   getEncodingInfo: function getEncodingInfo() {

--- a/lib/db/mysql/index.js
+++ b/lib/db/mysql/index.js
@@ -151,6 +151,7 @@ const QUERY_TOKEN_INSERT =
   'INSERT INTO tokens (clientId, userId, email, scope, type, token) VALUES ' +
   '(?, ?, ?, ?, ?, ?)';
 const QUERY_TOKEN_FIND = 'SELECT * FROM tokens WHERE token=?';
+const QUERY_TOKEN_LIST_USER = 'SELECT * FROM tokens WHERE userId=?';
 const QUERY_CODE_FIND = 'SELECT * FROM codes WHERE code=?';
 const QUERY_CODE_DELETE = 'DELETE FROM codes WHERE code=?';
 const QUERY_TOKEN_DELETE = 'DELETE FROM tokens WHERE token=?';
@@ -400,6 +401,16 @@ MysqlStore.prototype = {
         return info;
       });
     });
+  },
+
+  getUserTokens: function getUserTokens(userId) {
+    return this._read(QUERY_TOKEN_LIST_USER, [buf(userId)])
+      .then(function(rows) {
+        rows.forEach(function(t) {
+          t.scope = t.scope.split(' ');
+        });
+        return rows;
+      });
   },
 
   removeUser: function removeUser(userId) {

--- a/lib/encrypt.js
+++ b/lib/encrypt.js
@@ -8,6 +8,11 @@ const buf = require('buf').hex;
 
 const config = require('./config');
 
+exports.getHashSize = function getHashSize() {
+  var sha = crypto.createHash(config.get('encrypt.hashAlg'));
+  return sha.digest().length;
+};
+
 exports.hash = function hash(value) {
   var sha = crypto.createHash(config.get('encrypt.hashAlg'));
   sha.update(buf(value));

--- a/lib/routes/user/deleteToken.js
+++ b/lib/routes/user/deleteToken.js
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const Joi = require('joi');
+
+const auth = require('../../auth');
+const AppError = require('../../error');
+const db = require('../../db');
+const encrypt = require('../../encrypt');
+const unbuf = require('buf').unbuf.hex;
+const validators = require('../../validators');
+
+/*jshint camelcase: false*/
+
+module.exports = {
+  auth: {
+    strategy: auth.AUTH_STRATEGY,
+    scope: [auth.SCOPE_CLIENT_MANAGEMENT, auth.SCOPE_TOKEN_MANAGEMENT]
+  },
+  validate: {
+    params: {
+      token_id: Joi.string()
+        .length(encrypt.getHashSize() * 2) // hex = bytes*2
+        .regex(validators.HEX_STRING)
+        .required()
+    }
+  },
+  handler: function deleteTokenId(req, reply) {
+    db.getToken(req.params.token_id)
+    .then(function(tok) {
+      if (!tok) {
+        throw AppError.invalidToken();
+      }
+      var token = tok.token;
+      return db.removeToken(unbuf(token));
+    }).done(function() {
+      reply().code(204);
+    }, reply);
+  }
+};

--- a/lib/routes/user/deleteToken.js
+++ b/lib/routes/user/deleteToken.js
@@ -20,21 +20,19 @@ module.exports = {
   },
   validate: {
     params: {
-      token_id: Joi.string()
-        .length(encrypt.getHashSize() * 2) // hex = bytes*2
-        .regex(validators.HEX_STRING)
-        .required()
+      id: Joi.string()
+            .length(encrypt.getHashSize() * 2) // hex = bytes*2
+            .regex(validators.HEX_STRING)
+            .required()
     }
   },
   handler: function deleteTokenId(req, reply) {
-    db.getToken(req.params.token_id)
-    .then(function(tok) {
-      if (!tok) {
-        throw AppError.invalidToken();
+    db.removeToken(unbuf(req.params.id))
+    .done(function(ok) {
+      if (!ok) {
+        reply(AppError.invalidToken());
+        return;
       }
-      var token = tok.token;
-      return db.removeToken(unbuf(token));
-    }).done(function() {
       reply().code(204);
     }, reply);
   }

--- a/lib/routes/user/tokens.js
+++ b/lib/routes/user/tokens.js
@@ -13,7 +13,7 @@ const validators = require('../../validators');
 
 function serialize(token) {
   return {
-    token_id: unbuf(token.token),
+    id: unbuf(token.token),
     client_id: unbuf(token.clientId),
     token_type: token.type,
     scope: token.scope.join(' '),
@@ -30,7 +30,7 @@ module.exports = {
     schema: {
       tokens: Joi.array().includes(
         Joi.object().keys({
-          token_id: Joi.string().required(),
+          id: Joi.string().required(),
           client_id: validators.clientId,
           token_type: Joi.string().valid('bearer').required(),
           scope: Joi.string().required().allow(''),

--- a/lib/routes/user/tokens.js
+++ b/lib/routes/user/tokens.js
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const Joi = require('joi');
+
+const auth = require('../../auth');
+const db = require('../../db');
+const unbuf = require('buf').unbuf.hex;
+const validators = require('../../validators');
+
+/*jshint camelcase: false*/
+
+function serialize(token) {
+  return {
+    token_id: unbuf(token.token),
+    client_id: unbuf(token.clientId),
+    token_type: token.type,
+    scope: token.scope.join(' '),
+    created_at: +token.createdAt
+  };
+}
+
+module.exports = {
+  auth: {
+    strategy: auth.AUTH_STRATEGY,
+    scope: [auth.SCOPE_CLIENT_MANAGEMENT, auth.SCOPE_TOKEN_MANAGEMENT]
+  },
+  response: {
+    schema: {
+      tokens: Joi.array().includes(
+        Joi.object().keys({
+          token_id: Joi.string().required(),
+          client_id: validators.clientId,
+          token_type: Joi.string().valid('bearer').required(),
+          scope: Joi.string().required().allow(''),
+          created_at: Joi.number().required()
+        })
+      )
+    }
+  },
+  handler: function getTokens(req, reply) {
+    var userId = req.auth.credentials.user;
+    db.getUserTokens(userId).done(function(tokens) {
+      reply({
+        tokens: tokens.map(serialize)
+      });
+    }, reply);
+  }
+};

--- a/lib/routes/verify.js
+++ b/lib/routes/verify.js
@@ -22,7 +22,8 @@ module.exports = {
       user: Joi.string().required(),
       client_id: Joi.string().required(),
       scope: Joi.array(),
-      email: Joi.string()
+      email: Joi.string(),
+      created_at: Joi.number()
     }
   },
   handler: function verify(req, reply) {

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -64,7 +64,7 @@ exports.routes = [
   },
   {
     method: 'DELETE',
-    path: v('/user/token/{token_id}'),
+    path: v('/user/token/{id}'),
     config: require('./routes/user/deleteToken')
   }
 ];

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -56,6 +56,16 @@ exports.routes = [
     method: 'POST',
     path: v('/verify'),
     config: require('./routes/verify')
+  },
+  {
+    method: 'GET',
+    path: v('/user/tokens'),
+    config: require('./routes/user/tokens')
+  },
+  {
+    method: 'DELETE',
+    path: v('/user/token/{token_id}'),
+    config: require('./routes/user/deleteToken')
   }
 ];
 

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -5,6 +5,7 @@
 const Hapi = require('hapi');
 
 const AppError = require('../error');
+const auth = require('../auth');
 const config = require('../config').root();
 const logger = require('../logging')('server');
 const hapiLogger = require('../logging')('server.hapi');
@@ -24,6 +25,9 @@ exports.create = function createServer() {
     config.server.port,
     require('./config')
   );
+
+  server.auth.scheme(auth.AUTH_SCHEME, auth.strategy);
+  server.auth.strategy(auth.AUTH_STRATEGY, auth.AUTH_SCHEME);
 
   var routes = require('../routing').routes;
   if (isProd) {

--- a/lib/token.js
+++ b/lib/token.js
@@ -16,7 +16,8 @@ exports.verify = function verify(token) {
     var tokenInfo = {
       user: token.userId.toString('hex'),
       client_id: token.clientId.toString('hex'),
-      scope: token.scope
+      scope: token.scope,
+      created_at: +token.createdAt
     };
 
     // token.scope is a Set/Array

--- a/test/api.js
+++ b/test/api.js
@@ -1448,7 +1448,7 @@ describe('/v1', function() {
   describe('user', function() {
 
     var clientId = unique.id();
-    var tok, uid, vemail;
+    var tok;
     before(function() {
       return db.registerClient({
         name: 'test/api/user',
@@ -1465,8 +1465,6 @@ describe('/v1', function() {
       })
       .then(function(data) {
         tok = data.token;
-        uid = data.uid;
-        vemail = data.email;
       });
     });
 
@@ -1483,7 +1481,7 @@ describe('/v1', function() {
 
           var tokenInfo = res.result.tokens[0];
           assert.equal(tokenInfo.client_id, clientId.toString('hex'));
-          assert.equal(tokenInfo.token_id, encrypt.hash(tok).toString('hex'));
+          assert.equal(tokenInfo.id, encrypt.hash(tok).toString('hex'));
         });
       });
     });

--- a/test/api.js
+++ b/test/api.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const crypto = require('crypto');
 const url = require('url');
 const assert = require('insist');
 const bidcrypto = require('browserid-crypto');
@@ -1442,6 +1443,79 @@ describe('/v1', function() {
         });
       });
     });
+  });
+
+  describe('user', function() {
+
+    var clientId = unique.id();
+    var tok, uid, vemail;
+    before(function() {
+      return db.registerClient({
+        name: 'test/api/user',
+        id: clientId,
+        hashedSecret: encrypt.hash(unique.secret()),
+        redirectUri: 'https://example.domain',
+        imageUri: 'https://example.com/logo.png',
+        termsUri: 'https://example.com/legal/terms.html',
+        privacyUri: 'https://example.com/legal/privacy.html',
+        trusted: true
+      })
+      .then(function() {
+        return getUniqueUserAndToken(clientId.toString('hex'));
+      })
+      .then(function(data) {
+        tok = data.token;
+        uid = data.uid;
+        vemail = data.email;
+      });
+    });
+
+    describe('GET /user/tokens', function() {
+      it('should list tokens for a user', function() {
+        return Server.api.get({
+          url: '/user/tokens',
+          headers: {
+            authorization: 'Bearer ' + tok
+          }
+        }).then(function(res) {
+          assert.equal(res.statusCode, 200);
+          assert.equal(res.result.tokens.length, 1);
+
+          var tokenInfo = res.result.tokens[0];
+          assert.equal(tokenInfo.client_id, clientId.toString('hex'));
+          assert.equal(tokenInfo.token_id, encrypt.hash(tok).toString('hex'));
+        });
+      });
+    });
+
+    describe('DELETE /user/token/:id', function() {
+      it('should delete tokens by ID', function() {
+        return Server.api.delete({
+          url: '/user/token/' + encrypt.hash(tok).toString('hex'),
+          headers: {
+            authorization: 'Bearer ' + tok
+          }
+        }).then(function(res) {
+          assert.equal(res.statusCode, 204);
+          return db.getToken(encrypt.hash(tok)).then(function(tok) {
+            assert.equal(tok, undefined);
+          });
+        });
+      });
+    });
+
+    it('should return an error for invalid tokens', function() {
+      var badTokId = crypto.randomBytes(32).toString('hex');
+      return Server.api.delete({
+        url: '/user/token/' + badTokId,
+        headers: {
+          authorization: 'Bearer ' + tok
+        }
+      }).then(function(res) {
+        assert.equal(res.statusCode, 400);
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
This adds two endpoints for managing the tokens associated with an account:

* `GET /user/tokens`: Gets all active OAuth tokens for an account. Each token record contains a `token_id` field (the token hash, but callers can treat this as opaque) that can be used to destroy the token.
* `DELETE /user/token/{id}`: Revokes a token associated with an account.

Both endpoints are authenticated with a bearer token containing a privileged `oauth:tokens` scope. The revocation endpoint could be used by the device manager service, which would store token hashes for each OAuth token granted by `FxAccountsOAuthClient`. When the user logs out remotely, the device manager would destroy all token hashes associated with that device.