### PR TITLE
chore(release): add tasks "grunt version" and "grunt version:patch" 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "browserid-crypto": "^0.7.0",
     "eslint-config-fxa": "^1.8.0",
     "grunt": "^0.4.5",
+    "grunt-bump": "0.3.1",
     "grunt-cli": "^0.1.13",
     "grunt-conventional-changelog": "^1.1.0",
     "grunt-copyright": "^0.2.0",

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// takes care of bumping the version number in package.json
+
+module.exports = function (grunt) {
+  'use strict';
+
+  grunt.config('bump', {
+    options: {
+      files: ['package.json', 'npm-shrinkwrap.json'],
+      bumpVersion: true,
+      commit: true,
+      commitMessage: 'Release v%VERSION%',
+      commitFiles: ['package.json', 'npm-shrinkwrap.json', 'CHANGELOG'],
+      createTag: true,
+      tagName: 'v%VERSION%',
+      tagMessage: 'Version %VERSION%',
+      push: false,
+      pushTo: 'origin',
+      gitDescribeOptions: '--tags --always --abrev=1 --dirty=-d'
+    }
+  });
+};

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -13,7 +13,7 @@ module.exports = function (grunt) {
       bumpVersion: true,
       commit: true,
       commitMessage: 'Release v%VERSION%',
-      commitFiles: ['package.json', 'npm-shrinkwrap.json', 'CHANGELOG'],
+      commitFiles: ['package.json', 'npm-shrinkwrap.json', 'CHANGELOG.md'],
       createTag: true,
       tagName: 'v%VERSION%',
       tagMessage: 'Version %VERSION%',

--- a/tasks/version.js
+++ b/tasks/version.js
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//
+// A task to stamp a new version.
+//
+// Before running this task you should update CHANGELOG with the
+// changes for this release. Protip: you only need to make changes
+// to CHANGELOG; this task will add and commit for you.
+//
+// * version is updated in package.json
+// * git tag with version name is created.
+// * git commit with updated package.json created.
+//
+// NOTE: This task will not push this commit for you.
+//
+
+module.exports = function (grunt) {
+  'use strict';
+
+  grunt.registerTask('version', [
+    'bump-only:minor',
+    'bump-commit'
+  ]);
+
+  grunt.registerTask('version:patch', [
+    'bump-only:patch',
+    'bump-commit'
+  ]);
+};


### PR DESCRIPTION
to create release tags

Fixes https://github.com/mozilla/fxa-oauth-server/issues/159