### PR TITLE
refactor(config): Use human-readable duration values in config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -84,12 +84,12 @@ const conf = convict({
     accessToken: {
       doc: 'Access Tokens maximum expiration (can live shorter)',
       format: 'duration',
-      default: 1000 * 60 * 60 * 24 * 7 * 2 // 2 weeks
+      default: '2 weeks'
     },
     code: {
       doc: 'Clients must trade codes for tokens before they expire',
       format: 'duration',
-      default: 1000 * 60 * 15 // 15mins
+      default: '15 minutes'
     }
   },
   git: {


### PR DESCRIPTION
Fixes #296 