### PR TITLE
fix(sql): remove references to the `whitelisted` column; this is now the `trusted` column

### DIFF
--- a/lib/db/mysql/index.js
+++ b/lib/db/mysql/index.js
@@ -113,8 +113,8 @@ MysqlStore.connect = function mysqlConnect(options) {
 const QUERY_CLIENT_REGISTER =
   'INSERT INTO clients ' +
   '(id, name, imageUri, secret, redirectUri, termsUri, privacyUri, ' +
-  ' whitelisted, trusted, canGrant) ' +
-  'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
+  ' trusted, canGrant) ' +
+  'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);';
 const QUERY_CLIENT_DEVELOPER_INSERT =
   'INSERT INTO clientDevelopers ' +
   '(rowId, developerId, clientId) ' +
@@ -135,7 +135,7 @@ const QUERY_DEVELOPER_INSERT =
   'VALUES (?, ?);';
 const QUERY_CLIENT_GET = 'SELECT * FROM clients WHERE id=?';
 const QUERY_CLIENT_LIST = 'SELECT id, name, redirectUri, imageUri, ' +
-  'termsUri, privacyUri, canGrant, whitelisted, trusted ' +
+  'termsUri, privacyUri, canGrant, trusted ' +
   'FROM clients, clientDevelopers, developers ' +
   'WHERE clients.id = clientDevelopers.clientId AND ' +
   'developers.developerId = clientDevelopers.developerId AND ' +
@@ -144,8 +144,7 @@ const QUERY_CLIENT_UPDATE = 'UPDATE clients SET ' +
   'name=COALESCE(?, name), imageUri=COALESCE(?, imageUri), ' +
   'secret=COALESCE(?, secret), redirectUri=COALESCE(?, redirectUri), ' +
   'termsUri=COALESCE(?, termsUri), privacyUri=COALESCE(?, privacyUri), ' +
-  'whitelisted=COALESCE(?, whitelisted), trusted=COALESCE(?, trusted), ' +
-  'canGrant=COALESCE(?, canGrant) ' +
+  'trusted=COALESCE(?, trusted), canGrant=COALESCE(?, canGrant) ' +
   'WHERE id=?';
 const QUERY_CLIENT_DELETE = 'DELETE FROM clients WHERE id=?';
 const QUERY_CODE_INSERT =
@@ -215,8 +214,7 @@ MysqlStore.prototype = {
       client.redirectUri,
       client.termsUri || '',
       client.privacyUri || '',
-      !!client.trusted,  // XXX TODO: we have duplicate columns while we're
-      !!client.trusted,  // in the process of renaming whitelisted=>trusted.
+      !!client.trusted,
       !!client.canGrant
     ]).then(function() {
       logger.debug('registerClient.success', { id: hex(id) });
@@ -311,8 +309,7 @@ MysqlStore.prototype = {
       client.redirectUri,
       client.termsUri,
       client.privacyUri,
-      client.trusted,  // XXX TODO: we have duplicate columns while we're
-      client.trusted,  // in the process of renaming whitelisted => trusted.
+      client.trusted,
       client.canGrant,
 
       // WHERE

--- a/lib/routes/client/list.js
+++ b/lib/routes/client/list.js
@@ -18,8 +18,6 @@ function serialize(client) {
     terms_uri: client.termsUri,
     privacy_uri: client.privacyUri,
     can_grant: client.canGrant,
-    // XXX TODO: a future PR will remove legacy "whitelisted" attr
-    whitelisted: client.trusted,
     trusted: client.trusted
   };
 }
@@ -40,8 +38,6 @@ module.exports = {
           terms_uri: Joi.string().allow('').required(),
           privacy_uri: Joi.string().allow('').required(),
           can_grant: Joi.boolean().required(),
-          // XXX TODO: a future PR will remove legacy "whitelisted" attr
-          whitelisted: Joi.boolean().required(),
           trusted: Joi.boolean().required()
         })
       )

--- a/lib/routes/client/register.js
+++ b/lib/routes/client/register.js
@@ -25,8 +25,6 @@ module.exports = {
       terms_uri: Joi.string().max(256).allow(''),
       privacy_uri: Joi.string().max(256).allow(''),
       can_grant: Joi.boolean(),
-      // XXX TODO: a future PR will remove legacy "whitelisted" property
-      whitelisted: Joi.boolean(),
       trusted: Joi.boolean()
     }
   },
@@ -40,8 +38,6 @@ module.exports = {
       terms_uri: Joi.string().required().allow(''),
       privacy_uri: Joi.string().required().allow(''),
       can_grant: Joi.boolean().required(),
-      // XXX TODO: a future PR will remove legacy "whitelisted" property
-      whitelisted: Joi.boolean().required(),
       trusted: Joi.boolean().required()
     }
   },
@@ -57,11 +53,7 @@ module.exports = {
       termsUri: payload.terms_uri || '',
       privacyUri: payload.privacy_uri || '',
       canGrant: !!payload.can_grant,
-      // XXX TODO: a future PR will remove legacy "whitelisted" property.
-      // Accept both for now for API b/w compat.
-      trusted: !!(typeof payload.trusted !== 'undefined' ?
-                    payload.trusted :
-                    payload.whitelisted)
+      trusted: !!payload.trusted
     };
     var developerEmail = req.auth.credentials.email;
     var developerId = null;
@@ -91,8 +83,6 @@ module.exports = {
           terms_uri: client.termsUri,
           privacy_uri: client.privacyUri,
           can_grant: client.canGrant,
-          // XXX TODO: a future PR will remove legacy "whitelisted" property
-          whitelisted: client.trusted,
           trusted: client.trusted
         }).code(201);
       }, reply);

--- a/test/api.js
+++ b/test/api.js
@@ -911,7 +911,7 @@ describe('/v1', function() {
             hashedSecret: encrypt.hash(secret2),
             redirectUri: 'https://example.domain',
             imageUri: 'https://example.foo.domain/logo.png',
-            whitelisted: true
+            trusted: true
           };
           return db.registerClient(client2).then(function(c) {
             id2 = c.id.toString('hex');
@@ -1286,9 +1286,6 @@ describe('/v1', function() {
             assert(client.image_uri === '');
             assert(client.can_grant === false);
             assert(client.trusted === false);
-            // XXX TODO: future PR will remove legacy "whitelisted" attr,
-            // it's here for now for API b/w compat
-            assert(client.whitelisted === false);
             return db.getClient(client.id).then(function(klient) {
               assert.equal(klient.id.toString('hex'), client.id);
               assert.equal(klient.name, client.name);


### PR DESCRIPTION
fixes #301 

But this should only be merged after GH-302 

Puts back the parts that remove references to a `whitelisted` column, which can be dropped AFTER the train with this change is live and stable.

r? @seanmonstar 