### PR TITLE
chore(travis): use npm@2 for more stable installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
 
 before_install:
   - sudo apt-get install libgmp3-dev
+  - npm install -g npm@2
   - npm config set spin false
 
 before_script:


### PR DESCRIPTION
We should use npm@2 since the default with nodejs 0.10 is an obsolete and flaky version of npm (1.4.28). We already build production with npm@2.6.1; I'm not particularly concerned with what version travis uses as long as it in the 2.x series.

r? - @seanmonstar - note no need to merge this before train-42 is cut.