### PR TITLE
fix(events): require events to be configured in production

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -208,5 +208,4 @@ var options = {
 
 conf.validate(options);
 
-
 module.exports = conf;

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const config = require('./config');
+
+exports.isProdLike = function isProdLike() {
+  var env = config.get('env');
+  return env === 'prod' || env === 'stage';
+};

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -6,6 +6,7 @@ const Hapi = require('hapi');
 
 const AppError = require('../error');
 const config = require('../config').root();
+const env = require('../env');
 const logger = require('../logging')('server');
 const hapiLogger = require('../logging')('server.hapi');
 const summary = require('../logging/summary');
@@ -18,7 +19,7 @@ exports.create = function createServer() {
     logger.warn('localRedirect',
       '*** localRedirects is set to TRUE. Should only be used for developers.');
   }
-  var isProd = config.env === 'prod';
+  var isProd = env.isProdLike();
   var server = Hapi.createServer(
     config.server.host,
     config.server.port,

--- a/lib/server/internal.js
+++ b/lib/server/internal.js
@@ -7,12 +7,13 @@ const Hapi = require('hapi');
 const AppError = require('../error');
 const auth = require('../auth');
 const config = require('../config').root();
+const env = require('../env');
 const logger = require('../logging')('server.clients');
 const hapiLogger = require('../logging')('server.hapi');
 const summary = require('../logging/summary');
 
 exports.create = function createServer() {
-  var isProd = config.env === 'prod';
+  var isProd = env.isProdLike();
   var server = Hapi.createServer(
     config.serverInternal.host,
     config.serverInternal.port,


### PR DESCRIPTION
While abrupt, forgetting to delete user information is a big deal, so
this will prevent the server from running as long as the event queue is
not setup.

BREAKING CHANGE: Server will fail to start up if `config.events` is not
  set with values when in production.

See #310 

cc @ckolos: I noticed the puppet-config is missing these values, so they will need to be updated.