### PR TITLE
fix(db): we need to enforce only a minimum patch level (not {n,n+1})

### DIFF
--- a/lib/db/mysql/index.js
+++ b/lib/db/mysql/index.js
@@ -70,16 +70,17 @@ function checkDbPatchLevel(patcher) {
     if (err) {
       return d.reject(err);
     }
-    // We are only guaranteed to run correctly if we're at the current
-    // patch level for this version of the code (the normal state of
-    // affairs) or the one immediately above it (during a deployment).
-    if (patcher.currentPatchLevel !== patch.level) {
-      if (patcher.currentPatchLevel !== patch.level + 1) {
-        err = 'unexpected db patch level: ' + patcher.currentPatchLevel;
-        return d.reject(new Error(err));
-      }
+
+    // We can run if we're at or above some patch level.  Should be
+    // equal at initial deployment, and may be one or more higher
+    // later on, due to database changes in preparation for the next
+    // release.
+    if (patcher.currentPatchLevel >= patch.level) {
+      return d.resolve();
     }
-    d.resolve();
+
+    err = 'unexpected db patch level: ' + patcher.currentPatchLevel;
+    return d.reject(new Error(err));
   });
 
   return d.promise;

--- a/test/db/mysql.js
+++ b/test/db/mysql.js
@@ -139,12 +139,12 @@ describe('db/mysql:', function() {
 
       describe('db patch level is bad:', function() {
         beforeEach(function() {
-          instances.patcher.currentPatchLevel += 2;
+          instances.patcher.currentPatchLevel -= 2;
           return mysql.connect({});
         });
 
         afterEach(function() {
-          instances.patcher.currentPatchLevel -= 2;
+          instances.patcher.currentPatchLevel += 2;
         });
 
         it('called patcher.end', function() {
@@ -157,7 +157,7 @@ describe('db/mysql:', function() {
           assert.equal(args.length, 2);
           assert.equal(args[0], 'checkDbPatchLevel');
           assert(args[1] instanceof Error);
-          assert.equal(args[1].message, 'unexpected db patch level: ' + (dependencies['./patch'].level + 2));
+          assert.equal(args[1].message, 'unexpected db patch level: ' + (dependencies['./patch'].level - 2));
         });
 
         it('called process.exit', function() {


### PR DESCRIPTION
Hey, @seanmonstar - this is similar to the change in patch level restrictions we made for fxa-auth-db-mysql. It isn't always true that there is one db patch in each train, and train-42 has two (that amount to a no-op, but that's a different story). 

I will have to backport this to v0.41.1, where it will be slightly different due to other changes to this file. 
But first, I wanted to get this in master. 

r?