### PR TITLE
chore(version): add /__version__ route with source repo

### DIFF
--- a/lib/routes/root.js
+++ b/lib/routes/root.js
@@ -3,20 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const exec = require('child_process').exec;
-const fs = require('fs');
 const path = require('path');
 const util = require('util');
 
 const version = require('../../package.json').version;
+var commitHash, source;
 
 // See if config/version.json exists (part of rpm builds)
-var commitHash = (function() {
-  var sha;
+(function() {
   try {
-    sha = require('../../config/version.json');
-    sha = sha.version.hash;
+    var info = require('../../config/version.json');
+    commitHash = info.version.hash;
+    source = info.version.source;
   } catch(e) { /* ignore */ }
-  return sha;
 })();
 
 module.exports = {
@@ -24,7 +23,8 @@ module.exports = {
     function sendReply() {
       reply({
         version: version,
-        commit: commitHash
+        commit: commitHash,
+        source: source
       }).spaces(2);
     }
 
@@ -32,16 +32,15 @@ module.exports = {
       return sendReply();
     }
 
-    // figure it out from git (either '.git', or '/home/app/git' for AwsBox)
+    // figure it out from .git
     var gitDir = path.resolve(__dirname, '..', '..', '.git');
-    if (!fs.existsSync(gitDir)) {
-      // try at '/home/app/git' for AwsBox deploys
-      gitDir = path.sep + path.join('home', 'app', 'git');
-    }
     var cmd = util.format('git --git-dir=%s rev-parse HEAD', gitDir);
     exec(cmd, function(err, stdout) {
       commitHash = stdout.replace(/\s+/, '');
-      return sendReply();
+      exec('git config --get remote.origin.url', function(err, stdout) {
+        source = stdout.replace(/\s+/, '');
+        return sendReply();
+      });
     });
   }
 };

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -17,6 +17,11 @@ exports.routes = [
   },
   {
     method: 'GET',
+    path: '/__version__',
+    config: require('./routes/root')
+  },
+  {
+    method: 'GET',
     path: '/__heartbeat__',
     config: require('./routes/heartbeat')
   },


### PR DESCRIPTION
Fixes #321 . This preserves the `/` route but extends the output to include the git source repo, and adds an alternate route `/__version__` that serves the same content and a couple of more tests of the output. 

So content used to look like
```
{
  "version": "0.44.0",
  "commit": "e31f764c6dcfaeecc8e0ac531002eeab279137ea"
}
```
and is now like:
```
{
  "version": "0.44.0",
  "commit": "e31f764c6dcfaeecc8e0ac531002eeab279137ea",
  "source": "git://github.com/mozilla/fxa-oauth-server.git"
}
```