### PR TITLE
chore(tests): remove weird mocking magic

### DIFF
--- a/lib/db/mysql/index.js
+++ b/lib/db/mysql/index.js
@@ -11,7 +11,6 @@ const MysqlPatcher = require('mysql-patcher');
 
 const config = require('../../config');
 const encrypt = require('../../encrypt');
-const logger = require('../../logging')('db.mysql');
 const P = require('../../promise');
 const Scope = require('../../scope');
 const unique = require('../../unique');
@@ -19,6 +18,8 @@ const patch = require('./patch');
 
 const MAX_TTL = config.get('expiration.accessToken');
 
+// logger is not const to support mocking in the unit tests
+var logger = require('../../logging')('db.mysql');
 
 function MysqlStore(options) {
   if (options.charset && options.charset !== 'UTF8_UNICODE_CI') {
@@ -87,6 +88,9 @@ function checkDbPatchLevel(patcher) {
 }
 
 MysqlStore.connect = function mysqlConnect(options) {
+  if (options.logger) {
+    logger = options.logger;
+  }
 
   options.createDatabase = options.createSchema;
   options.dir = path.join(__dirname, 'patches');

--- a/test/lib/mocks.js
+++ b/test/lib/mocks.js
@@ -3,15 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const path = require('path');
-const proxyquire = require('proxyquire');
-const m = require('module');
-
-var moduleCache;
 
 module.exports = {
-  require: requireDependencies,
-  register: registerDependencies,
-  deregister: deregisterDependencies
+  require: requireDependencies
 };
 
 // `mocks.require`
@@ -56,56 +50,5 @@ function requireDependency(dependency, modulePath, basePath) {
   }
 
   return require(localPath);
-}
-
-// `mocks.register`
-//
-// Register mock dependencies, fixing paths as we go so that it works
-// with the blanket coverage tool (which rewrites require paths in the
-// instrumented code). You should call this function inside beforeEach.
-//
-// Expects three arguments; `dependencies`, `modulePath` and `basePath`.
-//
-// dependencies: An object, where keys are dependency paths and values
-//               are mock objects. This argument is typically the return
-//               value from `mocks.require`, modified by sinon for your
-//               tests.
-// modulePath:   The relative path to the module under test.
-// basePath:     The base path, i.e. __dirname for the test itself.
-function registerDependencies(dependencies, modulePath, basePath) {
-  var instrumentedDependencies = {};
-
-  clearModuleCache();
-
-  Object.keys(dependencies).forEach(function(dependencyPath) {
-    var instrumentedPath = getInstrumentedPath(dependencyPath, modulePath, basePath);
-    instrumentedDependencies[instrumentedPath] = dependencies[dependencyPath];
-  });
-
-  proxyquire(modulePath, instrumentedDependencies);
-}
-
-function clearModuleCache() {
-  moduleCache = m._cache;
-  m._cache = {};
-}
-
-function getInstrumentedPath(dependencyPath, modulePath, basePath) {
-  if (dependencyPath[0] !== '.') {
-    return dependencyPath;
-  }
-
-  return path.resolve(basePath, modulePath) + '/' + dependencyPath;
-}
-
-// `mocks.deregister`
-//
-// Deregister mock dependencies. You should call this function
-// inside afterEach.
-function deregisterDependencies() {
-  if (moduleCache) {
-    m._cache = moduleCache;
-    moduleCache = null;
-  }
 }
 


### PR DESCRIPTION
I meant to do this ages ago but forgot about it until it got mentioned in IRC the other day.

When I added the mocking stuff to this repo, I'd never used `proxyquire` before and assumed that it worked the same way as `mockery`. Of course, it doesn't.

So all the register/deregister module-cache hoop-jumping was completely unnecessary. Instead I should just have used the object returned by `proxyquire` directly.

The one thing that doesn't work using this approach is mocking the logger. So to stop those tests from failing, I've added an option for injecting the mock logger to `MysqlStore.connect`.