### PR TITLE
chore(clients): remove deprecated 'whitelisted' column from clients table

### DIFF
--- a/lib/db/mysql/patch.js
+++ b/lib/db/mysql/patch.js
@@ -6,4 +6,4 @@
 // Update this if you add a new patch, and don't forget to update
 // the documentation for the current schema in ../schema.sql.
 
-module.exports.level = 11;
+module.exports.level = 12;

--- a/lib/db/mysql/patches/patch-011-012.sql
+++ b/lib/db/mysql/patches/patch-011-012.sql
@@ -1,0 +1,5 @@
+-- Drop whitelisted column
+
+ALTER TABLE clients DROP COLUMN whitelisted;
+
+UPDATE dbMetadata SET value = '12' WHERE name = 'schema-patch-level';

--- a/lib/db/mysql/patches/patch-012-011.sql
+++ b/lib/db/mysql/patches/patch-012-011.sql
@@ -1,0 +1,6 @@
+--  (commented out to avoid accidentally running this in production...)
+
+-- ALTER TABLE clients ADD COLUMN whitelisted BOOLEAN DEFAULT FALSE;
+-- UPDATE clients SET whitelisted=trusted;
+
+-- UPDATE dbMetadata SET value = '11' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Fixes #267, which we had to revert the first time around.  Patch number 11 is already taken by #336, so I used 12 here and will have to rebase this atop that one once it merges.  The schema document is already sans `whitelisted` because that wasn't reverted when we rolled this back the first time around.

@seanmonstar r?