### PR TITLE
fix(travis): remove broken validate shrinkwrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
 
 script:
   - npm run outdated
-  - grunt validate-shrinkwrap test
+  - grunt test
 
 matrix:
   allow_failures:


### PR DESCRIPTION
I tried to update to grunt-nsp but that spewed errors about extraneous modules under node_modules/grunt-nsp. So just removing this broken test to fix travis. r? @seanmonstar