### PR TITLE
fix(travis): build on node 0.10, 0.12, 4, no allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,16 @@ language: node_js
 node_js:
   - '0.10'
   - '0.12'
-  - 'iojs'
+  - '4'
 
 sudo: false
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
 
 notifications:
   email:
@@ -25,6 +32,10 @@ before_install:
   - npm install -g npm@2
   - npm config set spin false
 
+install:
+  # use c++-11 with node4, default compiler on downlevel versions
+  - if [ $TRAVIS_NODE_VERSION == "4" ]; then CXX=g++-4.8 npm install; else npm install; fi
+
 before_script:
   - "mysql -NBe 'select version()'"
   - "mysql -e 'DROP DATABASE IF EXISTS fxa_oauth;'"
@@ -34,8 +45,3 @@ script:
   - npm run outdated
   - grunt test
   - grunt nsp --force
-
-matrix:
-  allow_failures:
-    - node_js: "iojs"
-  fast_finish: true

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -503,13 +503,11 @@
     },
     "generate-rsa-keypair": {
       "version": "0.1.0",
-      "from": "generate-rsa-keypair@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/generate-rsa-keypair/-/generate-rsa-keypair-0.1.0.tgz",
+      "resolved": "git://github.com/jrgm/node-generate-rsa-keypair.git#dce3504e0376920ebb4851eea42a3ee8cefa5a3f",
       "dependencies": {
         "nan": {
-          "version": "1.9.0",
-          "from": "nan@1.9.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz"
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "awsbox": "^0.7.0",
     "blanket": "^1.1.9",
     "eslint-config-fxa": "^1.8.0",
-    "generate-rsa-keypair": "^0.1.0",
+    "generate-rsa-keypair": "git://github.com/jrgm/node-generate-rsa-keypair.git#dce3504e0376920ebb4851eea42a3ee8cefa5a3f",
     "grunt": "^0.4.5",
     "grunt-bump": "0.3.1",
     "grunt-cli": "^0.1.13",


### PR DESCRIPTION
Needs to use my fork of node-generate-rsa-keypair to run on node 4.x. I left a PR on that repo to get that officially upgraded to 4.x, although maybe we could consider doing something on our own instead of using that module.

r? - @seanmonstar 