### PR TITLE
revert(tokens): dont reject expired tokens, again

### DIFF
--- a/lib/token.js
+++ b/lib/token.js
@@ -24,7 +24,7 @@ exports.verify = function verify(token) {
         created_at: token.createdAt,
         expires_at: token.expiresAt
       });
-      throw AppError.expiredToken(token.expiresAt);
+      //throw AppError.expiredToken(token.expiresAt);
     } else if ((+token.createdAt + TWENTY_FOUR_HOURS) < Date.now()) {
       // Log a warning if reliers are using access tokens that are more
       // than 24 hours old.  Eventually we will shorten the expiry time

--- a/test/api.js
+++ b/test/api.js
@@ -1814,7 +1814,7 @@ describe('/v1', function() {
       });
     });
 
-    it('should reject expired tokens', function() {
+    it.skip('should reject expired tokens', function() {
       this.slow(2200);
       return newToken({
         ttl: 1


### PR DESCRIPTION
We ran into some operational issues when deploying this, backing it out
so that we can get the rest of train-53 out the door.

@jrgm r?