### PR TITLE
fix(openid): Dynamicly generate openid keys 

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -93,12 +93,7 @@
     "fmt": "pretty"
   },
   "openid": {
-    "key": {
-      "kty": "RSA",
-      "kid": "2015.12.02-1",
-      "n":"xaQHsKpu1KSK-YEMoLzZS7Xxciy3fsGrhrrqW_JBrq3IRmeGLaqlE80zcpIVnStyp9tbet2niYTemt8ug591YWO5Y-S0EgQyFTxnGjzNOvAL6Cd2iGie9QeSehfFLNyRPdQiadYw07fw-h5gweMpVJv8nTgS-Bcorlw9JQM6Il1cUpbP0Lt-F_5qrzlaOiTEAAb4JGOusVh0n-MZfKt7w0mikauMH5KfhflwQDn4YTzRkWJzlldXr1Cs0ZkYzOwS4Hcoku7vd6lqCUO0GgZvkuvCFqdVKzpa4CGboNdfIjcGVF4f1CTQaQ0ao51cwLzq1pgi5aWYhVH7lJcm6O_BQw",
-      "e":"AQAB",
-      "d":"EM21aavT6Hhk6Hm0XSYxQ2KguJhcsYY90yKpMlASjYtw76t1mQRdLKXRrfgFpms_QE5CJNwblnGZi4lWJxKzpCgaZwfW14FL0Mpl6bEpsc0e9goE5ewfN64BIihLN1k5cAxNMLppRFbrQhi7GUD7DpqEi8lss3Mknk5xVGhF1Q38i5wSPLaLNgdt7QUIRdCCsrVFwnj83e8Rmmchr2-LXg2P_2KbVwdKfLuDiaYgDr2OELiK3VZa3WMexLrQHXGf1bvuK9xg6DNQ5Oe3slNWe7a0cpNR5oPX8HjqREmKciCFxHSA5o0ogyu5YvVjvZuh4Fm1iAM1fJNzYpabd_D8IQ"
-    }
+    "keyFile": "../config/key.json",
+    "key": {}
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -51,19 +51,10 @@
     "fmt": "pretty"
   },
   "openid": {
-    "key": {
-      "kty": "RSA",
-      "kid": "2015.12.16-1",
-      "n":"xaQHsKpu1KSK-YEMoLzZS7Xxciy3fsGrhrrqW_JBrq3IRmeGLaqlE80zcpIVnStyp9tbet2niYTemt8ug591YWO5Y-S0EgQyFTxnGjzNOvAL6Cd2iGie9QeSehfFLNyRPdQiadYw07fw-h5gweMpVJv8nTgS-Bcorlw9JQM6Il1cUpbP0Lt-F_5qrzlaOiTEAAb4JGOusVh0n-MZfKt7w0mikauMH5KfhflwQDn4YTzRkWJzlldXr1Cs0ZkYzOwS4Hcoku7vd6lqCUO0GgZvkuvCFqdVKzpa4CGboNdfIjcGVF4f1CTQaQ0ao51cwLzq1pgi5aWYhVH7lJcm6O_BQw",
-      "e":"AQAB",
-      "d":"EM21aavT6Hhk6Hm0XSYxQ2KguJhcsYY90yKpMlASjYtw76t1mQRdLKXRrfgFpms_QE5CJNwblnGZi4lWJxKzpCgaZwfW14FL0Mpl6bEpsc0e9goE5ewfN64BIihLN1k5cAxNMLppRFbrQhi7GUD7DpqEi8lss3Mknk5xVGhF1Q38i5wSPLaLNgdt7QUIRdCCsrVFwnj83e8Rmmchr2-LXg2P_2KbVwdKfLuDiaYgDr2OELiK3VZa3WMexLrQHXGf1bvuK9xg6DNQ5Oe3slNWe7a0cpNR5oPX8HjqREmKciCFxHSA5o0ogyu5YvVjvZuh4Fm1iAM1fJNzYpabd_D8IQ"
-    },
-    "oldKey": {
-      "kty": "RSA",
-      "kid": "2015.12.02-1",
-      "n":"xaQHsKpu1KSK-YEMoLzZS7Xxciy3esGrhrrqW_JBrq3IRmeGLaqlE80zcpIVnStyp9tbet2niYTemt8ug591YWO5Y-S0EgQyFTxnGjzNOvAL6Cd2iGie9QeSehfFLNyRPdQiadYw07fw-h5gweMpVJs8nTgS-Bcorlw9JQM6Il1cUpbP0Lt-F_5qrzlaOiTEAAb4JGOusVh0n-MZfKt7w0mikauMH5KfhflwQDn4YTzRkWJzlldXr1Cs0ZkYzOwS4Hcoku7vd6lqCUO0GgZvkuvCFqdVKzpa4CGboNdfIjcGVF4f1CTQaQ0ao51cwLzq1pgi5aWYhVH7lJcm6O_BQw",
-      "e":"AQAC"
-    }
+    "keyFile": "../config/key.json",
+    "oldKeyFile": "../config/oldKey.json",
+    "key": {},
+    "oldKey": {}
   },
   "serviceClients": [
     {

--- a/lib/config.js
+++ b/lib/config.js
@@ -154,6 +154,16 @@ const conf = convict({
     }
   },
   openid: {
+    keyFile: {
+      doc: 'Path to Private key JWK to sign id_tokens',
+      format: String,
+      default: ''
+    },
+    oldKeyFile: {
+      doc: 'Path to previous key that was used to sign id_tokens',
+      format: String,
+      default: ''
+    },
     key: {
       doc: 'Private JWK to sign id_tokens',
       default: {}
@@ -250,6 +260,15 @@ conf.get('serviceClients').forEach(function(client) {
   assert.equal(typeof client.scope, 'string', 'client scope required');
   assert.equal(typeof client.jku, 'string', 'client jku required');
 });
+
+// Replace openid key if file specified
+if (conf.get('openid.keyFile')){
+  conf.set('openid.key', require(conf.get('openid.keyFile')));
+}
+
+if (conf.get('openid.oldKeyFile')){
+  conf.set('openid.oldKey', require(conf.get('openid.oldKeyFile')));
+}
 
 var key = conf.get('openid.key');
 assert.equal(key.kty, 'RSA', 'openid.key.kty must be RSA');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,27 +4,27 @@
   "dependencies": {
     "blanket": {
       "version": "1.1.6",
-      "from": "blanket@1.1.6",
+      "from": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
       "dependencies": {
         "esprima": {
           "version": "1.0.4",
-          "from": "esprima@>=1.0.2 <1.1.0",
+          "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
         },
         "falafel": {
           "version": "0.1.6",
-          "from": "falafel@>=0.1.6 <0.2.0",
+          "from": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz",
           "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
         },
         "xtend": {
           "version": "2.1.2",
-          "from": "xtend@>=2.1.1 <2.2.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "dependencies": {
             "object-keys": {
               "version": "0.4.0",
-              "from": "object-keys@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
             }
           }
@@ -33,57 +33,57 @@
     },
     "bluebird": {
       "version": "2.10.2",
-      "from": "bluebird@2.10.2",
+      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
     },
     "buf": {
       "version": "0.1.0",
-      "from": "buf@0.1.0",
+      "from": "https://registry.npmjs.org/buf/-/buf-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/buf/-/buf-0.1.0.tgz"
     },
     "convict": {
       "version": "0.8.2",
-      "from": "convict@0.8.2",
+      "from": "https://registry.npmjs.org/convict/-/convict-0.8.2.tgz",
       "resolved": "https://registry.npmjs.org/convict/-/convict-0.8.2.tgz",
       "dependencies": {
         "cjson": {
           "version": "0.3.1",
-          "from": "cjson@0.3.1",
+          "from": "https://registry.npmjs.org/cjson/-/cjson-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.1.tgz",
           "dependencies": {
             "jsonlint": {
               "version": "1.6.0",
-              "from": "jsonlint@1.6.0",
+              "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "nomnom@>= 1.5.x",
+                  "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "underscore@~1.6.0",
+                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "chalk@~0.4.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "has-color@~0.1.0",
+                          "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "ansi-styles@~1.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "strip-ansi@~0.1.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -92,7 +92,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "JSV@>= 4.0.x",
+                  "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -101,54 +101,54 @@
         },
         "depd": {
           "version": "1.0.1",
-          "from": "depd@1.0.1",
+          "from": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
         },
         "moment": {
           "version": "2.10.3",
-          "from": "moment@2.10.3",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@0.6.1",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@~0.0.2",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@~0.0.1",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "validator": {
           "version": "3.40.0",
-          "from": "validator@3.40.0",
+          "from": "https://registry.npmjs.org/validator/-/validator-3.40.0.tgz",
           "resolved": "https://registry.npmjs.org/validator/-/validator-3.40.0.tgz"
         },
         "varify": {
           "version": "0.1.1",
-          "from": "varify@0.1.1",
+          "from": "https://registry.npmjs.org/varify/-/varify-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/varify/-/varify-0.1.1.tgz",
           "dependencies": {
             "through": {
               "version": "2.3.8",
-              "from": "through@~2.3.4",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             },
             "redeyed": {
               "version": "0.4.4",
-              "from": "redeyed@~0.4.2",
+              "from": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
               "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
               "dependencies": {
                 "esprima": {
                   "version": "1.0.4",
-                  "from": "esprima@~1.0.4",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                 }
               }
@@ -159,32 +159,32 @@
     },
     "eslint-config-fxa": {
       "version": "1.8.1",
-      "from": "eslint-config-fxa@1.8.1",
+      "from": "https://registry.npmjs.org/eslint-config-fxa/-/eslint-config-fxa-1.8.1.tgz",
       "resolved": "https://registry.npmjs.org/eslint-config-fxa/-/eslint-config-fxa-1.8.1.tgz"
     },
     "fxa-jwtool": {
       "version": "0.7.1",
-      "from": "fxa-jwtool@>=0.7.1 <0.8.0",
+      "from": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.7.1.tgz",
       "resolved": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.7.1.tgz",
       "dependencies": {
         "bluebird": {
           "version": "2.9.15",
-          "from": "bluebird@2.9.15",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.15.tgz",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.15.tgz"
         },
         "fetch": {
           "version": "0.3.6",
-          "from": "fetch@0.3.6",
+          "from": "https://registry.npmjs.org/fetch/-/fetch-0.3.6.tgz",
           "resolved": "https://registry.npmjs.org/fetch/-/fetch-0.3.6.tgz",
           "dependencies": {
             "encoding": {
               "version": "0.1.11",
-              "from": "encoding@*",
+              "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
               "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
               "dependencies": {
                 "iconv-lite": {
                   "version": "0.4.13",
-                  "from": "iconv-lite@0.4.13",
+                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
                   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                 }
               }
@@ -193,27 +193,27 @@
         },
         "pem-jwk": {
           "version": "1.5.1",
-          "from": "pem-jwk@1.5.1",
+          "from": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.5.1.tgz",
           "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.5.1.tgz",
           "dependencies": {
             "asn1.js": {
               "version": "1.0.3",
-              "from": "asn1.js@1.0.3",
+              "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@^2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimalistic-assert": {
                   "version": "1.0.0",
-                  "from": "minimalistic-assert@^1.0.0",
+                  "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                 },
                 "bn.js": {
                   "version": "1.3.0",
-                  "from": "bn.js@^1.0.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 }
               }
@@ -224,29 +224,29 @@
     },
     "fxa-notifier-aws": {
       "version": "1.0.0",
-      "from": "fxa-notifier-aws@1.0.0",
+      "from": "https://registry.npmjs.org/fxa-notifier-aws/-/fxa-notifier-aws-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/fxa-notifier-aws/-/fxa-notifier-aws-1.0.0.tgz",
       "dependencies": {
         "aws-sdk": {
           "version": "2.0.23",
-          "from": "aws-sdk@2.0.23",
+          "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.23.tgz",
           "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.23.tgz",
           "dependencies": {
             "xml2js": {
               "version": "0.2.6",
-              "from": "xml2js@0.2.6",
+              "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
               "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
               "dependencies": {
                 "sax": {
                   "version": "0.4.2",
-                  "from": "sax@0.4.2",
+                  "from": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz"
                 }
               }
             },
             "xmlbuilder": {
               "version": "0.4.2",
-              "from": "xmlbuilder@0.4.2",
+              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
             }
           }
@@ -267,62 +267,62 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "grunt@>=0.4.5 <0.5.0",
+      "from": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@0.1.22",
+          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@1.3.3",
+          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@0.6.2",
+          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
-          "from": "dateformat@1.0.2-1.2.3",
+          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@>=0.4.13 <0.5.0",
+          "from": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@0.1.3",
+          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~3.2.9",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.0",
-                      "from": "lru-cache@2",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@~1.0.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -331,171 +331,149 @@
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "lodash@~2.4.1",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@3.1.21",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@~1.2.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.2",
-              "from": "inherits@1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
+          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@0.2.11",
+          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@0.2.14",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.7.0",
-              "from": "lru-cache@2",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "sigmund@~1.0.0",
+              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@1.0.10",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "from": "abbrev@1",
+              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@2.2.8",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@0.9.2",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@2.2.1",
+          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.9",
-          "from": "which@1.0.9",
+          "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@2.0.5",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@~ 0.1.11",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@~1.7.0",
+                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@~2.4.0",
+                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.1.22",
-              "from": "async@0.1.22",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
-            },
-            "lodash": {
-              "version": "0.9.2",
-              "from": "lodash@0.9.2",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
-            },
-            "underscore.string": {
-              "version": "2.2.1",
-              "from": "underscore.string@2.2.1",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
-            },
-            "which": {
-              "version": "1.0.9",
-              "from": "which@1.0.9",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
-            }
-          }
+          "from": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.2",
-          "from": "grunt-legacy-log@0.1.2",
+          "from": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
           "dependencies": {
             "grunt-legacy-log-utils": {
               "version": "0.1.1",
-              "from": "grunt-legacy-log-utils@^0.1.1",
+              "from": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "lodash@~2.4.1",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@~2.3.3",
+              "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -504,61 +482,61 @@
     },
     "grunt-bump": {
       "version": "0.3.1",
-      "from": "grunt-bump@0.3.1",
+      "from": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.3.1.tgz",
       "dependencies": {
         "semver": {
           "version": "4.3.6",
-          "from": "semver@^4.3.3",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "grunt-cli": {
       "version": "0.1.13",
-      "from": "grunt-cli@>=0.1.13 <0.2.0",
+      "from": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@1.0.10",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "from": "abbrev@1",
+              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@0.1.3",
+          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~3.2.9",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.0",
-                      "from": "lru-cache@2",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@~1.0.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -567,127 +545,127 @@
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "lodash@~2.4.1",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
         "resolve": {
           "version": "0.3.1",
-          "from": "resolve@0.3.1",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
         }
       }
     },
     "grunt-conventional-changelog": {
       "version": "1.2.2",
-      "from": "grunt-conventional-changelog@1.2.2",
+      "from": "https://registry.npmjs.org/grunt-conventional-changelog/-/grunt-conventional-changelog-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/grunt-conventional-changelog/-/grunt-conventional-changelog-1.2.2.tgz",
       "dependencies": {
         "conventional-changelog": {
           "version": "0.0.17",
-          "from": "conventional-changelog@0.0.17",
+          "from": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.0.17.tgz",
           "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.0.17.tgz",
           "dependencies": {
             "dateformat": {
               "version": "1.0.11",
-              "from": "dateformat@^1.0.11",
+              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
               "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "5.0.0",
-                  "from": "get-stdin@*",
+                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.0.tgz"
                 },
                 "meow": {
                   "version": "3.4.2",
-                  "from": "meow@*",
+                  "from": "https://registry.npmjs.org/meow/-/meow-3.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.4.2.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@^1.0.0",
+                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "from": "camelcase@^1.0.1",
+                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@^1.0.0",
+                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
                     },
                     "loud-rejection": {
                       "version": "1.0.0",
-                      "from": "loud-rejection@^1.0.0",
+                      "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz"
                     },
                     "minimist": {
                       "version": "1.2.0",
-                      "from": "minimist@^1.1.3",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                     },
                     "normalize-package-data": {
                       "version": "2.3.4",
-                      "from": "normalize-package-data@^2.3.4",
+                      "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.4.tgz",
                       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.4.tgz",
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.1.4",
-                          "from": "hosted-git-info@^2.0.2",
+                          "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                         },
                         "is-builtin-module": {
                           "version": "1.0.0",
-                          "from": "is-builtin-module@^1.0.0",
+                          "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.0",
-                              "from": "builtin-modules@^1.0.0",
+                              "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
                             }
                           }
                         },
                         "semver": {
                           "version": "5.0.3",
-                          "from": "semver@2 || 3 || 4 || 5",
+                          "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
                         },
                         "validate-npm-package-license": {
                           "version": "3.0.1",
-                          "from": "validate-npm-package-license@^3.0.1",
+                          "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.1",
-                              "from": "spdx-correct@~1.0.0",
+                              "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.1.tgz",
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.0.2",
-                                  "from": "spdx-license-ids@^1.0.2",
+                                  "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz"
                                 }
                               }
                             },
                             "spdx-expression-parse": {
                               "version": "1.0.0",
-                              "from": "spdx-expression-parse@~1.0.0",
+                              "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.3",
-                                  "from": "spdx-exceptions@^1.0.0",
+                                  "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz",
                                   "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz"
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.0.2",
-                                  "from": "spdx-license-ids@^1.0.0",
+                                  "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz"
                                 }
                               }
@@ -698,32 +676,32 @@
                     },
                     "object-assign": {
                       "version": "4.0.1",
-                      "from": "object-assign@^4.0.1",
+                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                     },
                     "read-pkg-up": {
                       "version": "1.0.1",
-                      "from": "read-pkg-up@^1.0.1",
+                      "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                       "dependencies": {
                         "find-up": {
                           "version": "1.0.0",
-                          "from": "find-up@^1.0.0",
+                          "from": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
                           "dependencies": {
                             "path-exists": {
                               "version": "2.0.0",
-                              "from": "path-exists@^2.0.0",
+                              "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "1.0.0",
-                              "from": "pinkie-promise@^1.0.0",
+                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "1.0.0",
-                                  "from": "pinkie@^1.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                 }
                               }
@@ -732,56 +710,56 @@
                         },
                         "read-pkg": {
                           "version": "1.1.0",
-                          "from": "read-pkg@^1.0.0",
+                          "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                           "dependencies": {
                             "load-json-file": {
                               "version": "1.0.1",
-                              "from": "load-json-file@^1.0.0",
+                              "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
                               "dependencies": {
                                 "graceful-fs": {
                                   "version": "4.1.2",
-                                  "from": "graceful-fs@^4.1.2",
+                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
                                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                                 },
                                 "parse-json": {
                                   "version": "2.2.0",
-                                  "from": "parse-json@^2.2.0",
+                                  "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                   "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                   "dependencies": {
                                     "error-ex": {
                                       "version": "1.2.0",
-                                      "from": "error-ex@^1.2.0",
+                                      "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.2.0.tgz",
                                       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.2.0.tgz"
                                     }
                                   }
                                 },
                                 "pify": {
                                   "version": "2.2.0",
-                                  "from": "pify@^2.0.0",
+                                  "from": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "1.0.0",
-                                  "from": "pinkie-promise@^1.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "1.0.0",
-                                      "from": "pinkie@^1.0.0",
+                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                     }
                                   }
                                 },
                                 "strip-bom": {
                                   "version": "2.0.0",
-                                  "from": "strip-bom@^2.0.0",
+                                  "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                   "dependencies": {
                                     "is-utf8": {
                                       "version": "0.2.0",
-                                      "from": "is-utf8@^0.2.0",
+                                      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
                                       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
                                     }
                                   }
@@ -790,27 +768,27 @@
                             },
                             "path-type": {
                               "version": "1.0.0",
-                              "from": "path-type@^1.0.0",
+                              "from": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
                                   "version": "4.1.2",
-                                  "from": "graceful-fs@^4.1.2",
+                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
                                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                                 },
                                 "pify": {
                                   "version": "2.2.0",
-                                  "from": "pify@^2.0.0",
+                                  "from": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "1.0.0",
-                                  "from": "pinkie-promise@^1.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "1.0.0",
-                                      "from": "pinkie@^1.0.0",
+                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                     }
                                   }
@@ -823,27 +801,27 @@
                     },
                     "redent": {
                       "version": "1.0.0",
-                      "from": "redent@^1.0.0",
+                      "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                       "dependencies": {
                         "indent-string": {
                           "version": "2.1.0",
-                          "from": "indent-string@^2.1.0",
+                          "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                           "dependencies": {
                             "repeating": {
                               "version": "2.0.0",
-                              "from": "repeating@^2.0.0",
+                              "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
-                                  "from": "is-finite@^1.0.0",
+                                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
-                                      "from": "number-is-nan@^1.0.0",
+                                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                     }
                                   }
@@ -854,12 +832,12 @@
                         },
                         "strip-indent": {
                           "version": "1.0.1",
-                          "from": "strip-indent@^1.0.1",
+                          "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                           "dependencies": {
                             "get-stdin": {
                               "version": "4.0.1",
-                              "from": "get-stdin@^4.0.1",
+                              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                             }
                           }
@@ -868,7 +846,7 @@
                     },
                     "trim-newlines": {
                       "version": "1.0.0",
-                      "from": "trim-newlines@^1.0.0",
+                      "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                     }
                   }
@@ -877,69 +855,69 @@
             },
             "event-stream": {
               "version": "3.3.2",
-              "from": "event-stream@^3.3.0",
+              "from": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
               "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
               "dependencies": {
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@~2.3.1",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 },
                 "duplexer": {
                   "version": "0.1.1",
-                  "from": "duplexer@~0.1.1",
+                  "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                 },
                 "from": {
                   "version": "0.1.3",
-                  "from": "from@~0",
+                  "from": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
                 },
                 "map-stream": {
                   "version": "0.1.0",
-                  "from": "map-stream@~0.1.0",
+                  "from": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
                 },
                 "pause-stream": {
                   "version": "0.0.11",
-                  "from": "pause-stream@0.0.11",
+                  "from": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
                   "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
                 },
                 "split": {
                   "version": "0.3.3",
-                  "from": "split@0.3",
+                  "from": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
                 },
                 "stream-combiner": {
                   "version": "0.0.4",
-                  "from": "stream-combiner@~0.0.4",
+                  "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
                 }
               }
             },
             "github-url-from-git": {
               "version": "1.4.0",
-              "from": "github-url-from-git@^1.4.0",
+              "from": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz"
             },
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@^3.6.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "normalize-package-data": {
               "version": "1.0.3",
-              "from": "normalize-package-data@^1.0.3",
+              "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-1.0.3.tgz",
               "dependencies": {
                 "github-url-from-username-repo": {
                   "version": "1.0.2",
-                  "from": "github-url-from-username-repo@^1.0.0",
+                  "from": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz"
                 },
                 "semver": {
                   "version": "4.3.6",
-                  "from": "semver@2 || 3 || 4",
+                  "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                 }
               }
@@ -950,108 +928,108 @@
     },
     "grunt-copyright": {
       "version": "0.2.0",
-      "from": "grunt-copyright@0.2.0",
+      "from": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.2.0.tgz"
     },
     "grunt-eslint": {
       "version": "16.0.0",
-      "from": "grunt-eslint@16.0.0",
+      "from": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-16.0.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-16.0.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@^1.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@^2.1.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.2",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@^2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@^3.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@^2.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "eslint": {
           "version": "0.24.1",
-          "from": "eslint@^0.24.0",
+          "from": "https://registry.npmjs.org/eslint/-/eslint-0.24.1.tgz",
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.24.1.tgz",
           "dependencies": {
             "concat-stream": {
               "version": "1.5.1",
-              "from": "concat-stream@^1.4.6",
+              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "typedarray@~0.0.5",
+                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
                   "version": "2.0.2",
-                  "from": "readable-stream@~2.0.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.3",
-                      "from": "process-nextick-args@~1.0.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@~1.0.1",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -1060,286 +1038,286 @@
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@^2.1.1",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "doctrine": {
               "version": "0.6.4",
-              "from": "doctrine@^0.6.2",
+              "from": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
               "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "1.1.6",
-                  "from": "esutils@^1.1.6",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 }
               }
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.2",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "escope": {
               "version": "3.2.0",
-              "from": "escope@^3.1.0",
+              "from": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
               "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
               "dependencies": {
                 "es6-map": {
                   "version": "0.1.2",
-                  "from": "es6-map@^0.1.1",
+                  "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.2.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
-                      "from": "d@~0.1.1",
+                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
                       "version": "0.10.8",
-                      "from": "es5-ext@~0.10.8",
+                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz"
                     },
                     "es6-iterator": {
                       "version": "2.0.0",
-                      "from": "es6-iterator@2",
+                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
                     },
                     "es6-set": {
                       "version": "0.1.2",
-                      "from": "es6-set@~0.1.2",
+                      "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.2.tgz"
                     },
                     "es6-symbol": {
                       "version": "3.0.0",
-                      "from": "es6-symbol@3",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz"
                     },
                     "event-emitter": {
                       "version": "0.3.4",
-                      "from": "event-emitter@~0.3.4",
+                      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
                       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
                     }
                   }
                 },
                 "es6-weak-map": {
                   "version": "0.1.4",
-                  "from": "es6-weak-map@^0.1.2",
+                  "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
-                      "from": "d@~0.1.1",
+                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
                       "version": "0.10.8",
-                      "from": "es5-ext@~0.10.6",
+                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
                       "dependencies": {
                         "es6-iterator": {
                           "version": "2.0.0",
-                          "from": "es6-iterator@2",
+                          "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
                         },
                         "es6-symbol": {
                           "version": "3.0.0",
-                          "from": "es6-symbol@3",
+                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz"
                         }
                       }
                     },
                     "es6-iterator": {
                       "version": "0.1.3",
-                      "from": "es6-iterator@~0.1.3",
+                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                     },
                     "es6-symbol": {
                       "version": "2.0.1",
-                      "from": "es6-symbol@~2.0.1",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                     }
                   }
                 },
                 "esrecurse": {
                   "version": "3.1.1",
-                  "from": "esrecurse@^3.1.1",
+                  "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
                 },
                 "estraverse": {
                   "version": "3.1.0",
-                  "from": "estraverse@^3.1.0",
+                  "from": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
                 }
               }
             },
             "espree": {
               "version": "2.2.5",
-              "from": "espree@^2.0.1",
+              "from": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
               "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
             },
             "estraverse": {
               "version": "4.1.1",
-              "from": "estraverse@^4.1.0",
+              "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
             },
             "estraverse-fb": {
               "version": "1.3.1",
-              "from": "estraverse-fb@^1.3.1",
+              "from": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
             },
             "globals": {
               "version": "8.11.0",
-              "from": "globals@^8.0.0",
+              "from": "https://registry.npmjs.org/globals/-/globals-8.11.0.tgz",
               "resolved": "https://registry.npmjs.org/globals/-/globals-8.11.0.tgz"
             },
             "inquirer": {
               "version": "0.8.5",
-              "from": "inquirer@^0.8.2",
+              "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
               "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@^1.1.1",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "cli-width": {
                   "version": "1.1.0",
-                  "from": "cli-width@^1.0.1",
+                  "from": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz"
                 },
                 "figures": {
                   "version": "1.4.0",
-                  "from": "figures@^1.3.5",
+                  "from": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@^3.3.1",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "readline2": {
                   "version": "0.1.1",
-                  "from": "readline2@^0.1.1",
+                  "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
                   "dependencies": {
                     "mute-stream": {
                       "version": "0.0.4",
-                      "from": "mute-stream@0.0.4",
+                      "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
                     },
                     "strip-ansi": {
                       "version": "2.0.1",
-                      "from": "strip-ansi@^2.0.1",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
                     }
                   }
                 },
                 "rx": {
                   "version": "2.5.3",
-                  "from": "rx@^2.4.3",
+                  "from": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@^2.3.6",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "is-my-json-valid": {
               "version": "2.12.2",
-              "from": "is-my-json-valid@^2.10.0",
+              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
               "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "generate-function@^2.0.0",
+                  "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
-                  "from": "generate-object-property@^1.1.0",
+                  "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
-                      "from": "is-property@^1.0.0",
+                      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "2.0.0",
-                  "from": "jsonpointer@2.0.0",
+                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                 },
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "xtend@^4.0.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
             },
             "js-yaml": {
               "version": "3.4.3",
-              "from": "js-yaml@^3.2.5",
+              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.2",
-                  "from": "argparse@^1.0.2",
+                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>= 3.2.0 < 4.0.0",
+                      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "sprintf-js": {
                       "version": "1.0.3",
-                      "from": "sprintf-js@~1.0.2",
+                      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "2.6.0",
-                  "from": "esprima@^2.6.0",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@^2.0.1",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.1",
-                  "from": "brace-expansion@^1.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@^0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -1348,81 +1326,81 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@^0.5.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "object-assign": {
               "version": "2.1.1",
-              "from": "object-assign@^2.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
             },
             "optionator": {
               "version": "0.5.0",
-              "from": "optionator@^0.5.0",
+              "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
               "dependencies": {
                 "prelude-ls": {
                   "version": "1.1.2",
-                  "from": "prelude-ls@~1.1.1",
+                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                 },
                 "deep-is": {
                   "version": "0.1.3",
-                  "from": "deep-is@~0.1.2",
+                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 },
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "wordwrap@~0.0.2",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 },
                 "type-check": {
                   "version": "0.3.1",
-                  "from": "type-check@~0.3.1",
+                  "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                 },
                 "levn": {
                   "version": "0.2.5",
-                  "from": "levn@~0.2.5",
+                  "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
                   "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                 },
                 "fast-levenshtein": {
                   "version": "1.0.7",
-                  "from": "fast-levenshtein@~1.0.0",
+                  "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@^1.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.4",
-              "from": "strip-json-comments@~1.0.1",
+              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
             },
             "text-table": {
               "version": "0.2.0",
-              "from": "text-table@~0.2.0",
+              "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
             },
             "user-home": {
               "version": "1.1.1",
-              "from": "user-home@^1.0.0",
+              "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             },
             "xml-escape": {
               "version": "1.0.0",
-              "from": "xml-escape@~1.0.0",
+              "from": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
             }
           }
@@ -1431,181 +1409,181 @@
     },
     "grunt-jscs": {
       "version": "1.8.0",
-      "from": "grunt-jscs@1.8.0",
+      "from": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.8.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.8.0.tgz",
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
+          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "jscs": {
           "version": "1.13.1",
-          "from": "jscs@~1.13.0",
+          "from": "https://registry.npmjs.org/jscs/-/jscs-1.13.1.tgz",
           "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.13.1.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.0.0",
-              "from": "chalk@~1.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@^2.0.1",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.2",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "1.0.3",
-                  "from": "has-ansi@^1.0.3",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@^1.1.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     },
                     "get-stdin": {
                       "version": "4.0.1",
-                      "from": "get-stdin@^4.0.1",
+                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "2.0.1",
-                  "from": "strip-ansi@^2.0.1",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@^1.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "1.3.1",
-                  "from": "supports-color@^1.3.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
                 }
               }
             },
             "cli-table": {
               "version": "0.3.1",
-              "from": "cli-table@~0.3.1",
+              "from": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
               "dependencies": {
                 "colors": {
                   "version": "1.0.3",
-                  "from": "colors@1.0.3",
+                  "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.6.0",
-              "from": "commander@~2.6.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
             },
             "esprima": {
               "version": "1.2.5",
-              "from": "esprima@^1.2.5",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
             },
             "esprima-harmony-jscs": {
               "version": "1.1.0-bin",
-              "from": "esprima-harmony-jscs@1.1.0-bin",
+              "from": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-bin.tgz",
               "resolved": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-bin.tgz"
             },
             "estraverse": {
               "version": "1.9.3",
-              "from": "estraverse@^1.9.3",
+              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@~0.1.2",
+              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "glob": {
               "version": "5.0.15",
-              "from": "glob@^5.0.1",
+              "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@^1.0.4",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@^1.3.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@^1.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
             "lodash.assign": {
               "version": "3.0.0",
-              "from": "lodash.assign@~3.0.0",
+              "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
               "dependencies": {
                 "lodash._baseassign": {
                   "version": "3.2.0",
-                  "from": "lodash._baseassign@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
-                      "from": "lodash._basecopy@^3.0.0",
+                      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                     },
                     "lodash.keys": {
                       "version": "3.1.2",
-                      "from": "lodash.keys@^3.0.0",
+                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                       "dependencies": {
                         "lodash._getnative": {
                           "version": "3.9.1",
-                          "from": "lodash._getnative@^3.0.0",
+                          "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                         },
                         "lodash.isarguments": {
                           "version": "3.0.4",
-                          "from": "lodash.isarguments@^3.0.0",
+                          "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                         },
                         "lodash.isarray": {
                           "version": "3.0.4",
-                          "from": "lodash.isarray@^3.0.0",
+                          "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                         }
                       }
@@ -1614,22 +1592,22 @@
                 },
                 "lodash._createassigner": {
                   "version": "3.1.1",
-                  "from": "lodash._createassigner@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
                   "dependencies": {
                     "lodash._bindcallback": {
                       "version": "3.0.1",
-                      "from": "lodash._bindcallback@^3.0.0",
+                      "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                     },
                     "lodash._isiterateecall": {
                       "version": "3.0.9",
-                      "from": "lodash._isiterateecall@^3.0.0",
+                      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                     },
                     "lodash.restparam": {
                       "version": "3.6.1",
-                      "from": "lodash.restparam@^3.0.0",
+                      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                     }
                   }
@@ -1638,22 +1616,22 @@
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@~2.0.1",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.1",
-                  "from": "brace-expansion@^1.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@^0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -1662,101 +1640,101 @@
             },
             "pathval": {
               "version": "0.1.1",
-              "from": "pathval@~0.1.1",
+              "from": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz"
             },
             "prompt": {
               "version": "0.2.14",
-              "from": "prompt@~0.2.14",
+              "from": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
               "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
               "dependencies": {
                 "pkginfo": {
                   "version": "0.3.0",
-                  "from": "pkginfo@0.x.x",
+                  "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
                 },
                 "revalidator": {
                   "version": "0.1.8",
-                  "from": "revalidator@0.1.x",
+                  "from": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
                   "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
                 },
                 "utile": {
                   "version": "0.2.1",
-                  "from": "utile@0.2.x",
+                  "from": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@~0.2.9",
+                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "deep-equal": {
                       "version": "1.0.1",
-                      "from": "deep-equal@*",
+                      "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
                     },
                     "i": {
                       "version": "0.3.3",
-                      "from": "i@0.3.x",
+                      "from": "https://registry.npmjs.org/i/-/i-0.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@0.x.x",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "minimist@0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "ncp": {
                       "version": "0.4.2",
-                      "from": "ncp@0.4.x",
+                      "from": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                     },
                     "rimraf": {
                       "version": "2.4.3",
-                      "from": "rimraf@2.x.x",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
                     }
                   }
                 },
                 "winston": {
                   "version": "0.8.3",
-                  "from": "winston@0.8.x",
+                  "from": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
                   "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@0.2.x",
+                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "colors": {
                       "version": "0.6.2",
-                      "from": "colors@0.6.x",
+                      "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
                     },
                     "cycle": {
                       "version": "1.0.3",
-                      "from": "cycle@1.0.x",
+                      "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
                     },
                     "eyes": {
                       "version": "0.1.8",
-                      "from": "eyes@0.1.x",
+                      "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
                       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
                     },
                     "isstream": {
                       "version": "0.1.2",
-                      "from": "isstream@0.1.x",
+                      "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                     },
                     "stack-trace": {
                       "version": "0.0.9",
-                      "from": "stack-trace@0.0.x",
+                      "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
                       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                     }
                   }
@@ -1765,54 +1743,54 @@
             },
             "strip-json-comments": {
               "version": "1.0.4",
-              "from": "strip-json-comments@~1.0.2",
+              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
             },
             "vow-fs": {
               "version": "0.3.4",
-              "from": "vow-fs@~0.3.4",
+              "from": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
               "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
               "dependencies": {
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@^1.4.2",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "vow-queue": {
                   "version": "0.4.2",
-                  "from": "vow-queue@^0.4.1",
+                  "from": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz"
                 },
                 "glob": {
                   "version": "4.5.3",
-                  "from": "glob@^4.3.1",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@^1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@^1.3.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -1823,12 +1801,12 @@
             },
             "xmlbuilder": {
               "version": "2.6.5",
-              "from": "xmlbuilder@^2.6.1",
+              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.5.tgz",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.5.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@^3.5.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 }
               }
@@ -1837,34 +1815,34 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@~2.4.1",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "vow": {
           "version": "0.4.11",
-          "from": "vow@~0.4.1",
+          "from": "https://registry.npmjs.org/vow/-/vow-0.4.11.tgz",
           "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.11.tgz"
         }
       }
     },
     "grunt-mocha-test": {
       "version": "0.12.7",
-      "from": "grunt-mocha-test@latest",
+      "from": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.12.7.tgz",
       "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.12.7.tgz",
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
+          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
@@ -1873,49 +1851,49 @@
     },
     "grunt-nodemon": {
       "version": "0.4.0",
-      "from": "grunt-nodemon@>=0.4.0 <0.5.0",
+      "from": "https://registry.npmjs.org/grunt-nodemon/-/grunt-nodemon-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-nodemon/-/grunt-nodemon-0.4.0.tgz",
       "dependencies": {
         "nodemon": {
           "version": "1.3.8",
-          "from": "nodemon@1.3.8",
+          "from": "https://registry.npmjs.org/nodemon/-/nodemon-1.3.8.tgz",
           "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.3.8.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@~0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.0",
-                  "from": "lru-cache@2",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@~1.0.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "ps-tree": {
               "version": "0.0.3",
-              "from": "ps-tree@~0.0.3",
+              "from": "https://registry.npmjs.org/ps-tree/-/ps-tree-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-0.0.3.tgz",
               "dependencies": {
                 "event-stream": {
                   "version": "0.5.3",
-                  "from": "event-stream@~0.5",
+                  "from": "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz",
                   "dependencies": {
                     "optimist": {
                       "version": "0.2.8",
-                      "from": "optimist@0.2",
+                      "from": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
                       "dependencies": {
                         "wordwrap": {
                           "version": "0.0.3",
-                          "from": "wordwrap@>=0.0.1 <0.1.0",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                         }
                       }
@@ -1926,17 +1904,17 @@
             },
             "touch": {
               "version": "0.0.4",
-              "from": "touch@~0.0.3",
+              "from": "https://registry.npmjs.org/touch/-/touch-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.4.tgz",
               "dependencies": {
                 "nopt": {
                   "version": "1.0.10",
-                  "from": "nopt@~1.0.10",
+                  "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "abbrev@1",
+                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
@@ -1945,183 +1923,183 @@
             },
             "update-notifier": {
               "version": "0.3.2",
-              "from": "update-notifier@^0.3.0",
+              "from": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
               "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
               "dependencies": {
                 "chalk": {
                   "version": "1.1.1",
-                  "from": "chalk@^1.0.0",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.1.0",
-                      "from": "ansi-styles@^2.1.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "from": "escape-string-regexp@^1.0.2",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "from": "has-ansi@^2.0.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@^2.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.0",
-                      "from": "strip-ansi@^3.0.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@^2.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "from": "supports-color@^2.0.0",
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     }
                   }
                 },
                 "configstore": {
                   "version": "0.3.2",
-                  "from": "configstore@^0.3.1",
+                  "from": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "3.0.8",
-                      "from": "graceful-fs@^3.0.1",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                     },
                     "js-yaml": {
                       "version": "3.4.3",
-                      "from": "js-yaml@^3.1.0",
+                      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
                       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
                       "dependencies": {
                         "argparse": {
                           "version": "1.0.2",
-                          "from": "argparse@^1.0.2",
+                          "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                           "dependencies": {
                             "lodash": {
                               "version": "3.10.1",
-                              "from": "lodash@>= 3.2.0 < 4.0.0",
+                              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                             },
                             "sprintf-js": {
                               "version": "1.0.3",
-                              "from": "sprintf-js@~1.0.2",
+                              "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                             }
                           }
                         },
                         "esprima": {
                           "version": "2.6.0",
-                          "from": "esprima@^2.6.0",
+                          "from": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz"
                         }
                       }
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@^0.5.0",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "minimist@0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "object-assign": {
                       "version": "2.1.1",
-                      "from": "object-assign@^2.0.0",
+                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
                     },
                     "osenv": {
                       "version": "0.1.3",
-                      "from": "osenv@^0.1.0",
+                      "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                       "dependencies": {
                         "os-homedir": {
                           "version": "1.0.1",
-                          "from": "os-homedir@^1.0.0",
+                          "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                         },
                         "os-tmpdir": {
                           "version": "1.0.1",
-                          "from": "os-tmpdir@^1.0.0",
+                          "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                         }
                       }
                     },
                     "user-home": {
                       "version": "1.1.1",
-                      "from": "user-home@^1.0.0",
+                      "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
                     },
                     "uuid": {
                       "version": "2.0.1",
-                      "from": "uuid@^2.0.1",
+                      "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
                     },
                     "xdg-basedir": {
                       "version": "1.0.1",
-                      "from": "xdg-basedir@^1.0.0",
+                      "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
                     }
                   }
                 },
                 "is-npm": {
                   "version": "1.0.0",
-                  "from": "is-npm@^1.0.0",
+                  "from": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
                 },
                 "latest-version": {
                   "version": "1.0.1",
-                  "from": "latest-version@^1.0.0",
+                  "from": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
                   "dependencies": {
                     "package-json": {
                       "version": "1.2.0",
-                      "from": "package-json@^1.0.0",
+                      "from": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
                       "dependencies": {
                         "got": {
                           "version": "3.3.1",
-                          "from": "got@^3.2.0",
+                          "from": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
                           "dependencies": {
                             "duplexify": {
                               "version": "3.4.2",
-                              "from": "duplexify@^3.2.0",
+                              "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
                               "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
                               "dependencies": {
                                 "end-of-stream": {
                                   "version": "1.0.0",
-                                  "from": "end-of-stream@1.0.0",
+                                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                                   "dependencies": {
                                     "once": {
                                       "version": "1.3.2",
-                                      "from": "once@~1.3.0",
+                                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                                       "dependencies": {
                                         "wrappy": {
                                           "version": "1.0.1",
-                                          "from": "wrappy@1",
+                                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                         }
                                       }
@@ -2130,37 +2108,37 @@
                                 },
                                 "readable-stream": {
                                   "version": "2.0.2",
-                                  "from": "readable-stream@^2.0.0",
+                                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                                   "dependencies": {
                                     "core-util-is": {
                                       "version": "1.0.1",
-                                      "from": "core-util-is@~1.0.0",
+                                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                     },
                                     "inherits": {
                                       "version": "2.0.1",
-                                      "from": "inherits@~2.0.1",
+                                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     },
                                     "isarray": {
                                       "version": "0.0.1",
-                                      "from": "isarray@0.0.1",
+                                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                     },
                                     "process-nextick-args": {
                                       "version": "1.0.3",
-                                      "from": "process-nextick-args@~1.0.0",
+                                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
                                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "from": "string_decoder@~0.10.x",
+                                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                     },
                                     "util-deprecate": {
                                       "version": "1.0.2",
-                                      "from": "util-deprecate@~1.0.1",
+                                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                                     }
                                   }
@@ -2169,96 +2147,96 @@
                             },
                             "infinity-agent": {
                               "version": "2.0.3",
-                              "from": "infinity-agent@^2.0.0",
+                              "from": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
                             },
                             "is-redirect": {
                               "version": "1.0.0",
-                              "from": "is-redirect@^1.0.0",
+                              "from": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
                             },
                             "is-stream": {
                               "version": "1.0.1",
-                              "from": "is-stream@^1.0.0",
+                              "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
                             },
                             "lowercase-keys": {
                               "version": "1.0.0",
-                              "from": "lowercase-keys@^1.0.0",
+                              "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
                             },
                             "nested-error-stacks": {
                               "version": "1.0.1",
-                              "from": "nested-error-stacks@^1.0.0",
+                              "from": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
                               "dependencies": {
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@~2.0.1",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
                             },
                             "object-assign": {
                               "version": "3.0.0",
-                              "from": "object-assign@^3.0.0",
+                              "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                             },
                             "prepend-http": {
                               "version": "1.0.3",
-                              "from": "prepend-http@^1.0.0",
+                              "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
                             },
                             "read-all-stream": {
                               "version": "3.0.1",
-                              "from": "read-all-stream@^3.0.0",
+                              "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
                               "dependencies": {
                                 "pinkie-promise": {
                                   "version": "1.0.0",
-                                  "from": "pinkie-promise@^1.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "1.0.0",
-                                      "from": "pinkie@^1.0.0",
+                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                     }
                                   }
                                 },
                                 "readable-stream": {
                                   "version": "2.0.2",
-                                  "from": "readable-stream@^2.0.0",
+                                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                                   "dependencies": {
                                     "core-util-is": {
                                       "version": "1.0.1",
-                                      "from": "core-util-is@~1.0.0",
+                                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                     },
                                     "inherits": {
                                       "version": "2.0.1",
-                                      "from": "inherits@~2.0.1",
+                                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     },
                                     "isarray": {
                                       "version": "0.0.1",
-                                      "from": "isarray@0.0.1",
+                                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                     },
                                     "process-nextick-args": {
                                       "version": "1.0.3",
-                                      "from": "process-nextick-args@~1.0.0",
+                                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
                                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "from": "string_decoder@~0.10.x",
+                                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                     },
                                     "util-deprecate": {
                                       "version": "1.0.2",
-                                      "from": "util-deprecate@~1.0.1",
+                                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                                     }
                                   }
@@ -2267,39 +2245,39 @@
                             },
                             "timed-out": {
                               "version": "2.0.0",
-                              "from": "timed-out@^2.0.0",
+                              "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
                             }
                           }
                         },
                         "registry-url": {
                           "version": "3.0.3",
-                          "from": "registry-url@^3.0.0",
+                          "from": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
                           "dependencies": {
                             "rc": {
                               "version": "1.1.2",
-                              "from": "rc@^1.0.1",
+                              "from": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
                               "dependencies": {
                                 "minimist": {
                                   "version": "1.2.0",
-                                  "from": "minimist@^1.1.2",
+                                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                                 },
                                 "deep-extend": {
                                   "version": "0.2.11",
-                                  "from": "deep-extend@~0.2.5",
+                                  "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
                                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
                                 },
                                 "strip-json-comments": {
                                   "version": "0.1.3",
-                                  "from": "strip-json-comments@0.1.x",
+                                  "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
                                 },
                                 "ini": {
                                   "version": "1.3.4",
-                                  "from": "ini@~1.3.0",
+                                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
                                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                                 }
                               }
@@ -2312,29 +2290,29 @@
                 },
                 "semver-diff": {
                   "version": "2.0.0",
-                  "from": "semver-diff@^2.0.0",
+                  "from": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
                   "dependencies": {
                     "semver": {
                       "version": "4.3.6",
-                      "from": "semver@^4.0.0",
+                      "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                     }
                   }
                 },
                 "string-length": {
                   "version": "1.0.1",
-                  "from": "string-length@^1.0.0",
+                  "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
                   "dependencies": {
                     "strip-ansi": {
                       "version": "3.0.0",
-                      "from": "strip-ansi@^3.0.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@^2.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
@@ -2349,612 +2327,434 @@
     },
     "grunt-nsp": {
       "version": "2.1.2",
-      "from": "grunt-nsp@2.1.2",
+      "from": "https://registry.npmjs.org/grunt-nsp/-/grunt-nsp-2.1.2.tgz",
       "resolved": "https://registry.npmjs.org/grunt-nsp/-/grunt-nsp-2.1.2.tgz",
       "dependencies": {
         "nsp": {
           "version": "2.0.1",
-          "from": "nsp@2.0.1",
+          "from": "https://registry.npmjs.org/nsp/-/nsp-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/nsp/-/nsp-2.0.1.tgz",
           "dependencies": {
             "nodesecurity-npm-utils": {
               "version": "3.0.0",
-              "from": "nodesecurity-npm-utils@3.0.0",
+              "from": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-3.0.0.tgz"
             },
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@1.1.1",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
             },
             "cli-table": {
               "version": "0.3.1",
-              "from": "cli-table@0.3.1",
+              "from": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz"
             },
             "https-proxy-agent": {
               "version": "1.0.0",
-              "from": "https-proxy-agent@1.0.0",
+              "from": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz"
             },
             "joi": {
               "version": "6.10.0",
-              "from": "joi@6.10.0",
+              "from": "https://registry.npmjs.org/joi/-/joi-6.10.0.tgz",
               "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.0.tgz"
             },
             "rc": {
               "version": "1.1.2",
-              "from": "rc@1.1.2",
+              "from": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "minimist@1.2.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 }
               }
             },
             "semver": {
               "version": "5.0.3",
-              "from": "semver@5.0.3",
+              "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
             },
             "subcommand": {
               "version": "2.0.3",
-              "from": "subcommand@2.0.3",
+              "from": "https://registry.npmjs.org/subcommand/-/subcommand-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.0.3.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "minimist@1.2.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 }
               }
             },
             "wreck": {
               "version": "6.3.0",
-              "from": "wreck@6.3.0",
+              "from": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
               "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz"
             },
             "agent-base": {
               "version": "2.0.1",
-              "from": "agent-base@2.0.1",
+              "from": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz"
             },
             "ansi": {
               "version": "0.3.0",
-              "from": "ansi@0.3.0",
+              "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
             },
             "ansi-regex": {
               "version": "2.0.0",
-              "from": "ansi-regex@2.0.0",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             },
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@2.1.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-            },
-            "asn1": {
-              "version": "0.1.11",
-              "from": "asn1@0.1.11",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-            },
-            "assert-plus": {
-              "version": "0.1.5",
-              "from": "assert-plus@0.1.5",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-            },
-            "async": {
-              "version": "1.5.0",
-              "from": "async@1.5.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "from": "aws-sign2@0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "balanced-match": {
               "version": "0.2.1",
-              "from": "balanced-match@0.2.1",
+              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
-            },
-            "bl": {
-              "version": "1.0.0",
-              "from": "bl@1.0.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
             },
             "boom": {
               "version": "2.10.1",
-              "from": "boom@2.10.1",
+              "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "brace-expansion": {
               "version": "1.1.1",
-              "from": "brace-expansion@1.1.1",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz"
             },
             "builtin-modules": {
               "version": "1.1.0",
-              "from": "builtin-modules@1.1.0",
+              "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
-            },
-            "caseless": {
-              "version": "0.11.0",
-              "from": "caseless@0.11.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "chownr": {
               "version": "0.0.2",
-              "from": "chownr@0.0.2",
+              "from": "https://registry.npmjs.org/chownr/-/chownr-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/chownr/-/chownr-0.0.2.tgz"
             },
             "cliclopts": {
               "version": "1.1.1",
-              "from": "cliclopts@1.1.1",
+              "from": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz"
             },
             "colors": {
               "version": "1.0.3",
-              "from": "colors@1.0.3",
+              "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "from": "combined-stream@1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-            },
-            "commander": {
-              "version": "2.9.0",
-              "from": "commander@2.9.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
             },
             "concat-map": {
               "version": "0.0.1",
-              "from": "concat-map@0.0.1",
+              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
             },
             "concat-stream": {
               "version": "1.5.1",
-              "from": "concat-stream@1.5.1",
+              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz"
             },
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@1.0.1",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "from": "cryptiles@2.0.5",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-            },
-            "ctype": {
-              "version": "0.5.3",
-              "from": "ctype@0.5.3",
-              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@2.2.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
             },
             "deep-extend": {
               "version": "0.2.11",
-              "from": "deep-extend@0.2.11",
+              "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
               "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "from": "delayed-stream@1.0.0",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
             },
             "delegates": {
               "version": "0.1.0",
-              "from": "delegates@0.1.0",
+              "from": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@1.0.3",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@3.0.0",
+              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "from": "forever-agent@0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-            },
-            "form-data": {
-              "version": "1.0.0-rc3",
-              "from": "form-data@1.0.0-rc3",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
             },
             "gauge": {
               "version": "1.2.2",
-              "from": "gauge@1.2.2",
+              "from": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
               "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
-            },
-            "generate-function": {
-              "version": "2.0.0",
-              "from": "generate-function@2.0.0",
-              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-            },
-            "generate-object-property": {
-              "version": "1.2.0",
-              "from": "generate-object-property@1.2.0",
-              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
             },
             "glob": {
               "version": "5.0.15",
-              "from": "glob@5.0.15",
+              "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
             },
             "graceful-fs": {
               "version": "3.0.8",
-              "from": "graceful-fs@3.0.8",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-            },
-            "graceful-readlink": {
-              "version": "1.0.1",
-              "from": "graceful-readlink@1.0.1",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-            },
-            "har-validator": {
-              "version": "2.0.2",
-              "from": "har-validator@2.0.2",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
             },
             "has-unicode": {
               "version": "1.0.1",
-              "from": "has-unicode@1.0.1",
+              "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
-            },
-            "hawk": {
-              "version": "3.1.0",
-              "from": "hawk@3.1.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz"
             },
             "hoek": {
               "version": "2.16.3",
-              "from": "hoek@2.16.3",
+              "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
             "hosted-git-info": {
               "version": "2.1.4",
-              "from": "hosted-git-info@2.1.4",
+              "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
               "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
-            },
-            "http-signature": {
-              "version": "0.11.0",
-              "from": "http-signature@0.11.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
             },
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@1.0.4",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "ini": {
               "version": "1.3.4",
-              "from": "ini@1.3.4",
+              "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
             },
             "is-builtin-module": {
               "version": "1.0.0",
-              "from": "is-builtin-module@1.0.0",
+              "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
-            },
-            "is-my-json-valid": {
-              "version": "2.12.2",
-              "from": "is-my-json-valid@2.12.2",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz"
-            },
-            "is-property": {
-              "version": "1.0.2",
-              "from": "is-property@1.0.2",
-              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1"
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "isemail": {
               "version": "1.2.0",
-              "from": "isemail@1.2.0",
+              "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "jsonpointer": {
-              "version": "2.0.0",
-              "from": "jsonpointer@2.0.0",
-              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
             },
             "lodash._basetostring": {
               "version": "3.0.1",
-              "from": "lodash._basetostring@3.0.1",
+              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
             },
             "lodash._createpadding": {
               "version": "3.6.1",
-              "from": "lodash._createpadding@3.6.1",
+              "from": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
             },
             "lodash.pad": {
               "version": "3.1.1",
-              "from": "lodash.pad@3.1.1",
+              "from": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
             },
             "lodash.padleft": {
               "version": "3.1.1",
-              "from": "lodash.padleft@3.1.1",
+              "from": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
             },
             "lodash.padright": {
               "version": "3.1.1",
-              "from": "lodash.padright@3.1.1",
+              "from": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
             },
             "lodash.repeat": {
               "version": "3.0.1",
-              "from": "lodash.repeat@3.0.1",
+              "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
-            },
-            "mime-db": {
-              "version": "1.19.0",
-              "from": "mime-db@1.19.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.7",
-              "from": "mime-types@2.1.7",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "minimatch@3.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
             },
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
             },
             "moment": {
               "version": "2.10.6",
-              "from": "moment@2.10.6",
+              "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
             },
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-            },
-            "node-uuid": {
-              "version": "1.4.3",
-              "from": "node-uuid@1.4.3",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "normalize-package-data": {
               "version": "2.3.5",
-              "from": "normalize-package-data@2.3.5",
+              "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
               "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
             },
             "npm-package-arg": {
               "version": "4.0.2",
-              "from": "npm-package-arg@4.0.2",
+              "from": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.0.2.tgz",
               "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.0.2.tgz"
             },
             "npmlog": {
               "version": "1.2.1",
-              "from": "npmlog@1.2.1",
+              "from": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
-            },
-            "oauth-sign": {
-              "version": "0.8.0",
-              "from": "oauth-sign@0.8.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@1.3.2",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@1.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-            },
-            "pinkie": {
-              "version": "1.0.0",
-              "from": "pinkie@1.0.0",
-              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
-            },
-            "pinkie-promise": {
-              "version": "1.0.0",
-              "from": "pinkie-promise@1.0.0",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz"
             },
             "process-nextick-args": {
               "version": "1.0.3",
-              "from": "process-nextick-args@1.0.3",
+              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
-            },
-            "qs": {
-              "version": "5.2.0",
-              "from": "qs@5.2.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
             },
             "readable-stream": {
               "version": "2.0.4",
-              "from": "readable-stream@2.0.4",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz"
-            },
-            "request": {
-              "version": "2.65.0",
-              "from": "request@2.65.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz"
             },
             "retry": {
               "version": "0.6.1",
-              "from": "retry@0.6.1",
+              "from": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
             },
             "rimraf": {
               "version": "2.4.3",
-              "from": "rimraf@2.4.3",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
             },
             "silent-npm-registry-client": {
               "version": "1.0.0",
-              "from": "silent-npm-registry-client@1.0.0",
+              "from": "https://registry.npmjs.org/silent-npm-registry-client/-/silent-npm-registry-client-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/silent-npm-registry-client/-/silent-npm-registry-client-1.0.0.tgz"
             },
             "slide": {
               "version": "1.1.6",
-              "from": "slide@1.1.6",
+              "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "from": "sntp@1.0.9",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             },
             "spdx-correct": {
               "version": "1.0.2",
-              "from": "spdx-correct@1.0.2",
+              "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
             },
             "spdx-exceptions": {
               "version": "1.0.3",
-              "from": "spdx-exceptions@1.0.3",
+              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz"
             },
             "spdx-expression-parse": {
               "version": "1.0.0",
-              "from": "spdx-expression-parse@1.0.0",
+              "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz"
             },
             "spdx-license-ids": {
               "version": "1.1.0",
-              "from": "spdx-license-ids@1.1.0",
+              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@0.10.31",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@0.0.5",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@3.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
             },
             "strip-json-comments": {
               "version": "0.1.3",
-              "from": "strip-json-comments@0.1.3",
+              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@2.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             },
             "topo": {
               "version": "1.1.0",
-              "from": "topo@1.1.0",
+              "from": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.0",
-              "from": "tough-cookie@2.2.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.1",
-              "from": "tunnel-agent@0.4.1",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@0.0.6",
+              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "from": "util-deprecate@1.0.2",
+              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "from": "validate-npm-package-license@3.0.1",
+              "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
             },
             "wrappy": {
               "version": "1.0.1",
-              "from": "wrappy@1.0.1",
+              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@4.0.1"
-            },
-            "are-we-there-yet": {
-              "version": "1.0.4",
-              "from": "are-we-there-yet@1.0.4",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@1.1.13",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-                }
-              }
+              "from": "xtend@4.0.1",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             },
             "npm-registry-client": {
               "version": "6.3.3",
-              "from": "npm-registry-client@6.3.3",
+              "from": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-6.3.3.tgz",
               "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-6.3.3.tgz",
               "dependencies": {
                 "semver": {
                   "version": "4.3.6",
-                  "from": "semver@4.3.6",
+                  "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                }
+              }
+            },
+            "are-we-there-yet": {
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
                 }
               }
             }
@@ -2964,165 +2764,165 @@
     },
     "hapi": {
       "version": "7.5.3",
-      "from": "hapi@7.5.3",
+      "from": "https://registry.npmjs.org/hapi/-/hapi-7.5.3.tgz",
       "resolved": "https://registry.npmjs.org/hapi/-/hapi-7.5.3.tgz",
       "dependencies": {
         "accept": {
           "version": "1.0.0",
-          "from": "accept@1.0.0",
+          "from": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz"
         },
         "boom": {
           "version": "2.5.1",
-          "from": "boom@2.5.1",
+          "from": "https://registry.npmjs.org/boom/-/boom-2.5.1.tgz",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.5.1.tgz"
         },
         "call": {
           "version": "1.0.0",
-          "from": "call@1.0.0",
+          "from": "https://registry.npmjs.org/call/-/call-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/call/-/call-1.0.0.tgz"
         },
         "catbox": {
           "version": "4.1.0",
-          "from": "catbox@4.1.0",
+          "from": "https://registry.npmjs.org/catbox/-/catbox-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/catbox/-/catbox-4.1.0.tgz"
         },
         "catbox-memory": {
           "version": "1.1.0",
-          "from": "catbox-memory@1.1.0",
+          "from": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.0.tgz"
         },
         "cryptiles": {
           "version": "2.0.4",
-          "from": "cryptiles@2.0.4",
+          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "h2o2": {
           "version": "2.0.1",
-          "from": "h2o2@2.0.1",
+          "from": "https://registry.npmjs.org/h2o2/-/h2o2-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/h2o2/-/h2o2-2.0.1.tgz"
         },
         "heavy": {
           "version": "1.0.0",
-          "from": "heavy@1.0.0",
+          "from": "https://registry.npmjs.org/heavy/-/heavy-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/heavy/-/heavy-1.0.0.tgz"
         },
         "hoek": {
           "version": "2.9.0",
-          "from": "hoek@2.9.0",
+          "from": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz"
         },
         "glue": {
           "version": "1.0.0",
-          "from": "glue@1.0.0",
+          "from": "https://registry.npmjs.org/glue/-/glue-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/glue/-/glue-1.0.0.tgz"
         },
         "inert": {
           "version": "1.1.1",
-          "from": "inert@1.1.1",
+          "from": "https://registry.npmjs.org/inert/-/inert-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/inert/-/inert-1.1.1.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2.5.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             }
           }
         },
         "iron": {
           "version": "2.1.2",
-          "from": "iron@2.1.2",
+          "from": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz",
           "resolved": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz"
         },
         "items": {
           "version": "1.1.0",
-          "from": "items@1.1.0",
+          "from": "https://registry.npmjs.org/items/-/items-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/items/-/items-1.1.0.tgz"
         },
         "joi": {
           "version": "4.7.0",
-          "from": "joi@4.7.0",
+          "from": "https://registry.npmjs.org/joi/-/joi-4.7.0.tgz",
           "resolved": "https://registry.npmjs.org/joi/-/joi-4.7.0.tgz",
           "dependencies": {
             "isemail": {
               "version": "1.1.1",
-              "from": "isemail@1.1.1",
+              "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
             }
           }
         },
         "kilt": {
           "version": "1.1.1",
-          "from": "kilt@1.1.1",
+          "from": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz"
         },
         "mimos": {
           "version": "1.0.1",
-          "from": "mimos@1.0.1",
+          "from": "https://registry.npmjs.org/mimos/-/mimos-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/mimos/-/mimos-1.0.1.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.1.2",
-              "from": "mime-db@1.1.2",
+              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.1.2.tgz"
             }
           }
         },
         "qs": {
           "version": "2.3.2",
-          "from": "qs@2.3.2",
+          "from": "https://registry.npmjs.org/qs/-/qs-2.3.2.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.2.tgz"
         },
         "rejoice": {
           "version": "1.0.0",
-          "from": "rejoice@1.0.0",
+          "from": "https://registry.npmjs.org/rejoice/-/rejoice-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/rejoice/-/rejoice-1.0.0.tgz",
           "dependencies": {
             "bossy": {
               "version": "1.0.2",
-              "from": "bossy@1.0.2",
+              "from": "https://registry.npmjs.org/bossy/-/bossy-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/bossy/-/bossy-1.0.2.tgz"
             }
           }
         },
         "shot": {
           "version": "1.3.5",
-          "from": "shot@1.3.5",
+          "from": "https://registry.npmjs.org/shot/-/shot-1.3.5.tgz",
           "resolved": "https://registry.npmjs.org/shot/-/shot-1.3.5.tgz"
         },
         "statehood": {
           "version": "1.2.0",
-          "from": "statehood@1.2.0",
+          "from": "https://registry.npmjs.org/statehood/-/statehood-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/statehood/-/statehood-1.2.0.tgz"
         },
         "subtext": {
           "version": "1.0.2",
-          "from": "subtext@1.0.2",
+          "from": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
           "dependencies": {
             "content": {
               "version": "1.0.1",
-              "from": "content@1.0.1",
+              "from": "https://registry.npmjs.org/content/-/content-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/content/-/content-1.0.1.tgz"
             },
             "pez": {
               "version": "1.0.0",
-              "from": "pez@1.0.0",
+              "from": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
               "dependencies": {
                 "b64": {
                   "version": "2.0.0",
-                  "from": "b64@2.0.0",
+                  "from": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz"
                 },
                 "nigel": {
                   "version": "1.0.1",
-                  "from": "nigel@1.0.1",
+                  "from": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
                   "dependencies": {
                     "vise": {
                       "version": "1.0.0",
-                      "from": "vise@1.0.0",
+                      "from": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz"
                     }
                   }
@@ -3133,115 +2933,115 @@
         },
         "topo": {
           "version": "1.0.2",
-          "from": "topo@1.0.2",
+          "from": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "vision": {
           "version": "1.2.1",
-          "from": "vision@1.2.1",
+          "from": "https://registry.npmjs.org/vision/-/vision-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/vision/-/vision-1.2.1.tgz"
         },
         "wreck": {
           "version": "5.0.1",
-          "from": "wreck@5.0.1",
+          "from": "https://registry.npmjs.org/wreck/-/wreck-5.0.1.tgz",
           "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.0.1.tgz"
         }
       }
     },
     "insist": {
       "version": "0.2.3",
-      "from": "insist@0.2.3",
+      "from": "https://registry.npmjs.org/insist/-/insist-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/insist/-/insist-0.2.3.tgz",
       "dependencies": {
         "esprima": {
           "version": "1.0.4",
-          "from": "esprima@~1.0.4",
+          "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
         },
         "stack-trace": {
           "version": "0.0.9",
-          "from": "stack-trace@~0.0.7",
+          "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
           "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
         }
       }
     },
     "joi": {
       "version": "4.9.0",
-      "from": "joi@4.9.0",
+      "from": "https://registry.npmjs.org/joi/-/joi-4.9.0.tgz",
       "resolved": "https://registry.npmjs.org/joi/-/joi-4.9.0.tgz",
       "dependencies": {
         "hoek": {
           "version": "2.16.3",
-          "from": "hoek@^2.2.x",
+          "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
         "topo": {
           "version": "1.1.0",
-          "from": "topo@1.x.x",
+          "from": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
         },
         "isemail": {
           "version": "1.2.0",
-          "from": "isemail@1.x.x",
+          "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
         },
         "moment": {
           "version": "2.10.6",
-          "from": "moment@2.x.x",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
         }
       }
     },
     "load-grunt-tasks": {
       "version": "3.3.0",
-      "from": "load-grunt-tasks@3.3.0",
+      "from": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.3.0.tgz",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.3.0.tgz",
       "dependencies": {
         "arrify": {
           "version": "1.0.0",
-          "from": "arrify@^1.0.0",
+          "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
         },
         "multimatch": {
           "version": "2.0.0",
-          "from": "multimatch@^2.0.0",
+          "from": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "1.0.0",
-              "from": "array-differ@^1.0.0",
+              "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
             },
             "array-union": {
               "version": "1.0.1",
-              "from": "array-union@^1.0.1",
+              "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "1.0.2",
-                  "from": "array-uniq@^1.0.1",
+                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@^2.0.1",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.1",
-                  "from": "brace-expansion@^1.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@^0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -3252,27 +3052,27 @@
         },
         "pkg-up": {
           "version": "1.0.0",
-          "from": "pkg-up@^1.0.0",
+          "from": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
           "dependencies": {
             "find-up": {
               "version": "1.0.0",
-              "from": "find-up@^1.0.0",
+              "from": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
               "dependencies": {
                 "path-exists": {
                   "version": "2.0.0",
-                  "from": "path-exists@^2.0.0",
+                  "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz"
                 },
                 "pinkie-promise": {
                   "version": "1.0.0",
-                  "from": "pinkie-promise@^1.0.0",
+                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "1.0.0",
-                      "from": "pinkie@^1.0.0",
+                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                     }
                   }
@@ -3392,130 +3192,132 @@
     },
     "mocha-text-cov": {
       "version": "0.1.0",
-      "from": "mocha-text-cov@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/mocha-text-cov/-/mocha-text-cov-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/mocha-text-cov/-/mocha-text-cov-0.1.0.tgz"
     },
     "mozlog": {
       "version": "2.0.2",
       "from": "mozlog@2.0.2",
+      "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.2.tgz",
       "dependencies": {
         "intel": {
           "version": "1.0.2",
-          "from": "intel@^1.0.0",
+          "from": "intel@1.0.2",
+          "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.2.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@~1.1.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@^2.1.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.2",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@^2.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@^3.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@^2.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "dbug": {
               "version": "0.4.2",
-              "from": "dbug@~0.4.2",
+              "from": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@~0.0.9",
+              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             },
             "strftime": {
               "version": "0.9.2",
-              "from": "strftime@~0.9.2",
+              "from": "https://registry.npmjs.org/strftime/-/strftime-0.9.2.tgz",
               "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.9.2.tgz"
             },
             "symbol": {
               "version": "0.2.1",
-              "from": "symbol@~0.2.0",
+              "from": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
             },
             "utcstring": {
               "version": "0.1.0",
-              "from": "utcstring@~0.1.0",
+              "from": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
             }
           }
         },
         "merge": {
           "version": "1.2.0",
-          "from": "merge@^1.2.0",
+          "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
         }
       }
     },
     "mysql": {
       "version": "2.9.0",
-      "from": "mysql@2.9.0",
+      "from": "https://registry.npmjs.org/mysql/-/mysql-2.9.0.tgz",
       "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.9.0.tgz",
       "dependencies": {
         "bignumber.js": {
           "version": "2.0.7",
-          "from": "bignumber.js@2.0.7",
+          "from": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.0.7.tgz",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.0.7.tgz"
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@~1.1.13",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@~1.0.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@~0.10.x",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
@@ -3524,64 +3326,59 @@
     },
     "mysql-patcher": {
       "version": "0.7.0",
-      "from": "mysql-patcher@>=0.7.0 <0.8.0",
+      "from": "https://registry.npmjs.org/mysql-patcher/-/mysql-patcher-0.7.0.tgz",
       "resolved": "https://registry.npmjs.org/mysql-patcher/-/mysql-patcher-0.7.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "async@0.9.2",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-        },
-        "bluebird": {
-          "version": "2.10.2",
-          "from": "bluebird@2.10.2",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
         },
         "clone": {
           "version": "0.1.19",
-          "from": "clone@0.1.19",
+          "from": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
         },
         "glob": {
           "version": "5.0.15",
-          "from": "glob@5.0.15",
+          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@^1.0.4",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "minimatch@2 || 3",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.1",
-                  "from": "brace-expansion@^1.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@^0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -3590,53 +3387,53 @@
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@^1.3.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@^1.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
         },
         "xtend": {
           "version": "4.0.0",
-          "from": "xtend@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
         }
       }
     },
     "nock": {
       "version": "1.9.0",
-      "from": "nock@1.9.0",
+      "from": "https://registry.npmjs.org/nock/-/nock-1.9.0.tgz",
       "resolved": "https://registry.npmjs.org/nock/-/nock-1.9.0.tgz",
       "dependencies": {
         "chai": {
           "version": "1.10.0",
-          "from": "chai@^1.9.2",
+          "from": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
           "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
           "dependencies": {
             "assertion-error": {
               "version": "1.0.0",
-              "from": "assertion-error@1.0.0",
+              "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
             },
             "deep-eql": {
               "version": "0.1.3",
-              "from": "deep-eql@0.1.3",
+              "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
               "dependencies": {
                 "type-detect": {
                   "version": "0.1.1",
-                  "from": "type-detect@0.1.1",
+                  "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
                 }
               }
@@ -3645,77 +3442,94 @@
         },
         "debug": {
           "version": "1.0.4",
-          "from": "debug@^1.0.4",
+          "from": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "ms@0.6.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@2.4.1",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@^0.5.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "propagate": {
           "version": "0.3.1",
-          "from": "propagate@0.3.x",
+          "from": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
+        }
+      }
+    },
+    "node-rsa": {
+      "version": "0.2.30",
+      "from": "node-rsa@>=0.2.30 <0.3.0",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-0.2.30.tgz",
+      "dependencies": {
+        "asn1": {
+          "version": "0.2.3",
+          "from": "asn1@0.2.3",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+        },
+        "lodash": {
+          "version": "3.3.0",
+          "from": "lodash@3.3.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.3.0.tgz"
         }
       }
     },
     "proxyquire": {
       "version": "1.7.3",
-      "from": "proxyquire@1.7.3",
+      "from": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.7.3.tgz",
       "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.7.3.tgz",
       "dependencies": {
         "fill-keys": {
           "version": "1.0.2",
-          "from": "fill-keys@^1.0.2",
+          "from": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
           "dependencies": {
             "is-object": {
               "version": "1.0.1",
-              "from": "is-object@~1.0.1",
+              "from": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz"
             },
             "merge-descriptors": {
               "version": "1.0.0",
-              "from": "merge-descriptors@~1.0.0",
+              "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz"
             }
           }
         },
         "module-not-found-error": {
           "version": "1.0.1",
-          "from": "module-not-found-error@^1.0.0",
+          "from": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz"
         }
       }
     },
     "read": {
       "version": "1.0.7",
-      "from": "read@1.0.7",
+      "from": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "dependencies": {
         "mute-stream": {
           "version": "0.0.5",
-          "from": "mute-stream@~0.0.4",
+          "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
         }
       }
@@ -3727,42 +3541,42 @@
       "dependencies": {
         "bl": {
           "version": "1.0.0",
-          "from": "bl@~1.0.0",
+          "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.4",
-              "from": "readable-stream@~2.0.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.3",
-                  "from": "process-nextick-args@~1.0.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@~1.0.1",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -3771,254 +3585,254 @@
         },
         "caseless": {
           "version": "0.11.0",
-          "from": "caseless@~0.11.0",
+          "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
         },
         "extend": {
           "version": "3.0.0",
-          "from": "extend@~3.0.0",
+          "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "forever-agent@~0.6.1",
+          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
           "version": "1.0.0-rc3",
-          "from": "form-data@~1.0.0-rc3",
+          "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
           "dependencies": {
             "async": {
               "version": "1.5.0",
-              "from": "async@^1.4.0",
+              "from": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
             }
           }
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "json-stringify-safe@~5.0.1",
+          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
           "version": "2.1.7",
-          "from": "mime-types@~2.1.7",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.19.0",
-              "from": "mime-db@~1.19.0",
+              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
             }
           }
         },
         "node-uuid": {
           "version": "1.4.3",
-          "from": "node-uuid@~1.4.3",
+          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
         },
         "qs": {
           "version": "5.2.0",
-          "from": "qs@~5.2.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.1",
-          "from": "tunnel-agent@~0.4.1",
+          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
         },
         "tough-cookie": {
           "version": "2.2.0",
-          "from": "tough-cookie@~2.2.0",
+          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
         },
         "http-signature": {
           "version": "0.11.0",
-          "from": "http-signature@~0.11.0",
+          "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "assert-plus@^0.1.5",
+              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "asn1@0.1.11",
+              "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
               "version": "0.5.3",
-              "from": "ctype@0.5.3",
+              "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
             }
           }
         },
         "oauth-sign": {
           "version": "0.8.0",
-          "from": "oauth-sign@~0.8.0",
+          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
         },
         "hawk": {
           "version": "3.1.1",
-          "from": "hawk@~3.1.0",
+          "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.1.tgz",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.1.tgz",
           "dependencies": {
             "hoek": {
               "version": "2.16.3",
-              "from": "hoek@2.x.x",
+              "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
             "boom": {
               "version": "2.10.1",
-              "from": "boom@^2.8.x",
+              "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "cryptiles": {
               "version": "2.0.5",
-              "from": "cryptiles@2.x.x",
+              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "sntp@1.x.x",
+              "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "from": "aws-sign2@~0.6.0",
+          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
-          "from": "stringstream@~0.0.4",
+          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "combined-stream@~1.0.5",
+          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "1.0.0",
-              "from": "delayed-stream@~1.0.0",
+              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
             }
           }
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "isstream@~0.1.2",
+          "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "har-validator": {
           "version": "2.0.2",
-          "from": "har-validator@~2.0.2",
+          "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@^1.1.1",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@^2.1.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.2",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@^2.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@^3.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@^2.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.9.0",
-              "from": "commander@^2.8.1",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
-                  "from": "graceful-readlink@>= 1.0.0",
+                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "is-my-json-valid": {
               "version": "2.12.3",
-              "from": "is-my-json-valid@^2.12.2",
+              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
               "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "generate-function@^2.0.0",
+                  "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
-                  "from": "generate-object-property@^1.1.0",
+                  "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
-                      "from": "is-property@^1.0.0",
+                      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "2.0.0",
-                  "from": "jsonpointer@2.0.0",
+                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@^4.0.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "pinkie-promise": {
               "version": "1.0.0",
-              "from": "pinkie-promise@^1.0.0",
+              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
               "dependencies": {
                 "pinkie": {
                   "version": "1.0.0",
-                  "from": "pinkie@^1.0.0",
+                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                 }
               }
@@ -4029,213 +3843,213 @@
     },
     "sinon": {
       "version": "1.17.1",
-      "from": "sinon@1.17.1",
+      "from": "https://registry.npmjs.org/sinon/-/sinon-1.17.1.tgz",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.1.tgz",
       "dependencies": {
         "formatio": {
           "version": "1.1.1",
-          "from": "formatio@1.1.1",
+          "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
         },
         "util": {
           "version": "0.10.3",
-          "from": "util@>=0.10.3 <1",
+          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "lolex": {
           "version": "1.3.2",
-          "from": "lolex@1.3.2",
+          "from": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz"
         },
         "samsam": {
           "version": "1.1.2",
-          "from": "samsam@1.1.2",
+          "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
         }
       }
     },
     "time-grunt": {
       "version": "1.2.1",
-      "from": "time-grunt@1.2.1",
+      "from": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.2.1.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@1.1.1",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@^2.1.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.2",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@^2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@^3.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@^2.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "date-time": {
           "version": "1.0.0",
-          "from": "date-time@^1.0.0",
+          "from": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz"
         },
         "figures": {
           "version": "1.4.0",
-          "from": "figures@^1.0.0",
+          "from": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@^0.2.3",
+          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "number-is-nan": {
           "version": "1.0.0",
-          "from": "number-is-nan@^1.0.0",
+          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
         },
         "pretty-ms": {
           "version": "1.4.0",
-          "from": "pretty-ms@^1.0.0",
+          "from": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-1.4.0.tgz",
           "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-1.4.0.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@^4.0.1",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "is-finite": {
               "version": "1.0.1",
-              "from": "is-finite@^1.0.1",
+              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
             },
             "meow": {
               "version": "3.4.2",
-              "from": "meow@^3.3.0",
+              "from": "https://registry.npmjs.org/meow/-/meow-3.4.2.tgz",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.4.2.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@^1.0.0",
+                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@^1.0.1",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "map-obj@^1.0.0",
+                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "loud-rejection": {
                   "version": "1.0.0",
-                  "from": "loud-rejection@^1.0.0",
+                  "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz"
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "minimist@^1.1.3",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "normalize-package-data": {
                   "version": "2.3.4",
-                  "from": "normalize-package-data@^2.3.4",
+                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.4.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.4.tgz",
                   "dependencies": {
                     "hosted-git-info": {
                       "version": "2.1.4",
-                      "from": "hosted-git-info@^2.0.2",
+                      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
-                      "from": "is-builtin-module@^1.0.0",
+                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.0",
-                          "from": "builtin-modules@^1.0.0",
+                          "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
                         }
                       }
                     },
                     "semver": {
                       "version": "5.0.3",
-                      "from": "semver@2 || 3 || 4 || 5",
+                      "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
-                      "from": "validate-npm-package-license@^3.0.1",
+                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.1",
-                          "from": "spdx-correct@~1.0.0",
+                          "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.1.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.0.2",
-                              "from": "spdx-license-ids@^1.0.2",
+                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.0",
-                          "from": "spdx-expression-parse@~1.0.0",
+                          "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
                           "dependencies": {
                             "spdx-exceptions": {
                               "version": "1.0.3",
-                              "from": "spdx-exceptions@^1.0.0",
+                              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz"
                             },
                             "spdx-license-ids": {
                               "version": "1.0.2",
-                              "from": "spdx-license-ids@^1.0.0",
+                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz"
                             }
                           }
@@ -4246,32 +4060,32 @@
                 },
                 "object-assign": {
                   "version": "4.0.1",
-                  "from": "object-assign@^4.0.1",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                 },
                 "read-pkg-up": {
                   "version": "1.0.1",
-                  "from": "read-pkg-up@^1.0.1",
+                  "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "dependencies": {
                     "find-up": {
                       "version": "1.0.0",
-                      "from": "find-up@^1.0.0",
+                      "from": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
                       "dependencies": {
                         "path-exists": {
                           "version": "2.0.0",
-                          "from": "path-exists@^2.0.0",
+                          "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "1.0.0",
-                          "from": "pinkie-promise@^1.0.0",
+                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "1.0.0",
-                              "from": "pinkie@^1.0.0",
+                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                             }
                           }
@@ -4280,56 +4094,56 @@
                     },
                     "read-pkg": {
                       "version": "1.1.0",
-                      "from": "read-pkg@^1.0.0",
+                      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "dependencies": {
                         "load-json-file": {
                           "version": "1.0.1",
-                          "from": "load-json-file@^1.0.0",
+                          "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.2",
-                              "from": "graceful-fs@^4.1.2",
+                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                             },
                             "parse-json": {
                               "version": "2.2.0",
-                              "from": "parse-json@^2.2.0",
+                              "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.2.0",
-                                  "from": "error-ex@^1.2.0",
+                                  "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.2.0.tgz",
                                   "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.2.0.tgz"
                                 }
                               }
                             },
                             "pify": {
                               "version": "2.2.0",
-                              "from": "pify@^2.0.0",
+                              "from": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "1.0.0",
-                              "from": "pinkie-promise@^1.0.0",
+                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "1.0.0",
-                                  "from": "pinkie@^1.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                 }
                               }
                             },
                             "strip-bom": {
                               "version": "2.0.0",
-                              "from": "strip-bom@^2.0.0",
+                              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                               "dependencies": {
                                 "is-utf8": {
                                   "version": "0.2.0",
-                                  "from": "is-utf8@^0.2.0",
+                                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
                                   "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
                                 }
                               }
@@ -4338,27 +4152,27 @@
                         },
                         "path-type": {
                           "version": "1.0.0",
-                          "from": "path-type@^1.0.0",
+                          "from": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.2",
-                              "from": "graceful-fs@^4.1.2",
+                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                             },
                             "pify": {
                               "version": "2.2.0",
-                              "from": "pify@^2.0.0",
+                              "from": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "1.0.0",
-                              "from": "pinkie-promise@^1.0.0",
+                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "1.0.0",
-                                  "from": "pinkie@^1.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                 }
                               }
@@ -4371,50 +4185,50 @@
                 },
                 "redent": {
                   "version": "1.0.0",
-                  "from": "redent@^1.0.0",
+                  "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "dependencies": {
                     "indent-string": {
                       "version": "2.1.0",
-                      "from": "indent-string@^2.1.0",
+                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "2.0.0",
-                          "from": "repeating@^2.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz"
                         }
                       }
                     },
                     "strip-indent": {
                       "version": "1.0.1",
-                      "from": "strip-indent@^1.0.1",
+                      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                     }
                   }
                 },
                 "trim-newlines": {
                   "version": "1.0.0",
-                  "from": "trim-newlines@^1.0.0",
+                  "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                 }
               }
             },
             "parse-ms": {
               "version": "1.0.0",
-              "from": "parse-ms@^1.0.0",
+              "from": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.0.tgz"
             },
             "plur": {
               "version": "1.0.0",
-              "from": "plur@^1.0.0",
+              "from": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@^0.2.0",
+          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "grunt server --node-env=dev",
     "test": "grunt test --node-env=test",
-    "outdated": "npm outdated --depth 0"
+    "outdated": "npm outdated --depth 0",
+    "postinstall": "node scripts/gen_keys"
   },
   "repository": {
     "type": "git",
@@ -22,7 +23,6 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "urijs": "^1.16.1",
     "bluebird": "^2.9.14",
     "buf": "0.1.0",
     "convict": "0.8",
@@ -33,7 +33,8 @@
     "mozlog": "^2.0.2",
     "mysql": "^2.5.5",
     "mysql-patcher": "^0.7.0",
-    "request": "^2.54.0"
+    "request": "^2.54.0",
+    "urijs": "^1.16.1"
   },
   "devDependencies": {
     "blanket": "1.1.6",
@@ -53,6 +54,7 @@
     "load-grunt-tasks": "^3.1.0",
     "mocha-text-cov": "^0.1.0",
     "nock": "^1.2.1",
+    "node-rsa": "^0.2.30",
     "proxyquire": "^1.6.0",
     "read": "^1.0.5",
     "sinon": "^1.15.4",

--- a/scripts/gen_keys.js
+++ b/scripts/gen_keys.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+
+ Usage:
+ scripts/gen_keys.js
+
+ Will create these files
+
+ ./config/key.json
+ ./config/oldKey.json
+
+ If these files already exist, this script will show an error message
+ and exit. You must remove both keys if you want to generate a new
+ keypair.
+ */
+
+const fs = require('fs');
+const assert = require('assert');
+
+const NodeRSA = require('node-rsa');
+
+const keyPath = './config/key.json';
+const oldKeyPath = './config/oldKey.json';
+
+try {
+  var keysExist = fs.existsSync(keyPath) && fs.existsSync(oldKeyPath);
+  assert(!keysExist, 'keys already exists');
+} catch (e) {
+  process.exit();
+}
+
+function main(cb) {
+  var key = new NodeRSA({b: 2048});
+
+  var genKey = {
+    kty: 'RSA',
+    kid: '2015.12.16-1',
+    n: key.keyPair.n.toString(),
+    e: key.keyPair.e.toString(),
+    d: key.keyPair.d.toString()
+  };
+
+  var genOldKey = {
+    kty: 'RSA',
+    kid: '2015.12.16-2',
+    n: key.keyPair.n.toString(),
+    e: key.keyPair.e.toString()
+  };
+
+  fs.writeFileSync(keyPath, JSON.stringify(genKey));
+  console.log('Key saved:', keyPath); //eslint-disable-line no-console
+
+  fs.writeFileSync(oldKeyPath, JSON.stringify(genOldKey));
+  console.log('OldKey saved:', oldKeyPath); //eslint-disable-line no-console
+  cb();
+}
+
+module.exports = main;
+
+if (require.main === module) {
+  main(function () {
+  });
+}


### PR DESCRIPTION
This PR adds the ability to generate dynamic OpenId keys which is needed by https://github.com/mozilla/fxa-dev/issues/212. The files, key.json and oldKey.json are created via npm postinstall script. If the environment configuration specifies a `keyPath` or `oldKeyPath`, then these keys will be loaded into the openid configuration.