### PR TITLE
Add support for changing client key with no downtime

### DIFF
--- a/config/test.json
+++ b/config/test.json
@@ -3,6 +3,7 @@
     {
       "id": "dcdb5ae7add825d2",
       "hashedSecret": "289a885946ee316844d9ffd0d725ee714901548a1e6507f1a40fb3c2ae0c99f1",
+      "hashedSecretPrevious": "0726282857047586fb4edc335b5492ef1e4a0d95d3f1114627bb89b4e57cf6e1",
       "name": "Mocha",
       "imageUri": "https://example.domain/logo",
       "redirectUri": "https://example.domain/return?foo=bar",

--- a/lib/db/index.js
+++ b/lib/db/index.js
@@ -33,11 +33,10 @@ function clientEquals(configClient, dbClient) {
 
 function convertClientToConfigFormat(client) {
   var out = {};
+
   for (var key in client) {
-    if (key === 'createdAt') {
-      continue;
-    } else if (key === 'hashedSecret') {
-      out.hashedSecret = unbuf(client.hashedSecret);
+    if (key === 'hashedSecret' || key === 'hashedSecretPrevious') {
+      out[key] = unbuf(client[key]);
     } else if (key === 'trusted' || key === 'canGrant') {
       out[key] = !!client[key]; // db stores booleans as 0 or 1.
     } else if (key === 'termsUri' || key === 'privacyUri') {

--- a/lib/db/memory.js
+++ b/lib/db/memory.js
@@ -20,6 +20,7 @@ const MAX_TTL = config.get('expiration.accessToken');
  *     <id>: {
  *       id: <id>,
  *       hashedSecret: <string>,
+ *       hashedSecretPrevious: <string>,
  *       name: <string>,
  *       imageUri: <string>,
  *       redirectUri: <string>,
@@ -134,6 +135,7 @@ MemoryStore.prototype = {
     client.trusted = !!client.trusted;
     this.clients[hex] = client;
     client.hashedSecret = client.hashedSecret;
+    client.hashedSecretPrevious = client.hashedSecretPrevious || '';
     return P.resolve(client);
   },
   updateClient: function updateClient(client) {
@@ -150,6 +152,8 @@ MemoryStore.prototype = {
         // nothing
       } else if (key === 'hashedSecret') {
         old.hashedSecret = buf(client[key]);
+      } else if (key === 'hashedSecretPrevious') {
+        old.hashedSecretPrevious = buf(client[key]);
       } else if (client[key] !== undefined) {
         old[key] = client[key];
       }

--- a/lib/db/mysql/index.js
+++ b/lib/db/mysql/index.js
@@ -118,9 +118,9 @@ MysqlStore.connect = function mysqlConnect(options) {
 
 const QUERY_CLIENT_REGISTER =
   'INSERT INTO clients ' +
-  '(id, name, imageUri, hashedSecret, redirectUri, termsUri,' +
+  '(id, name, imageUri, hashedSecret, hashedSecretPrevious, redirectUri, termsUri,' +
   'privacyUri, trusted, canGrant) ' +
-  'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);';
+  'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
 const QUERY_CLIENT_DEVELOPER_INSERT =
   'INSERT INTO clientDevelopers ' +
   '(rowId, developerId, clientId) ' +
@@ -149,6 +149,7 @@ const QUERY_CLIENT_LIST = 'SELECT id, name, redirectUri, imageUri, ' +
 const QUERY_CLIENT_UPDATE = 'UPDATE clients SET ' +
   'name=COALESCE(?, name), imageUri=COALESCE(?, imageUri), ' +
   'hashedSecret=COALESCE(?, hashedSecret), ' +
+  'hashedSecretPrevious=COALESCE(?, hashedSecretPrevious), ' +
   'redirectUri=COALESCE(?, redirectUri), ' +
   'termsUri=COALESCE(?, termsUri), privacyUri=COALESCE(?, privacyUri), ' +
   'trusted=COALESCE(?, trusted), canGrant=COALESCE(?, canGrant) ' +
@@ -218,6 +219,7 @@ MysqlStore.prototype = {
       client.name,
       client.imageUri || '',
       buf(client.hashedSecret),
+      client.hashedSecretPrevious ? buf(client.hashedSecretPrevious) : null,
       client.redirectUri,
       client.termsUri || '',
       client.privacyUri || '',
@@ -308,11 +310,17 @@ MysqlStore.prototype = {
     if (secret) {
       secret = buf(secret);
     }
+
+    var secretPrevious = client.hashedSecretPrevious;
+    if (secretPrevious) {
+      secretPrevious = buf(secretPrevious);
+    }
     return this._write(QUERY_CLIENT_UPDATE, [
       // VALUES
       client.name,
       client.imageUri,
       secret,
+      secretPrevious,
       client.redirectUri,
       client.termsUri,
       client.privacyUri,

--- a/lib/db/mysql/patch.js
+++ b/lib/db/mysql/patch.js
@@ -6,4 +6,4 @@
 // Update this if you add a new patch, and don't forget to update
 // the documentation for the current schema in ../schema.sql.
 
-module.exports.level = 13;
+module.exports.level = 14;

--- a/lib/db/mysql/patches/patch-013-014.sql
+++ b/lib/db/mysql/patches/patch-013-014.sql
@@ -1,0 +1,5 @@
+-- Add hashedSecretPrevious column
+
+ALTER TABLE clients ADD COLUMN hashedSecretPrevious BINARY(32);
+
+UPDATE dbMetadata SET value = '14' WHERE name = 'schema-patch-level';

--- a/lib/db/mysql/patches/patch-014-013.sql
+++ b/lib/db/mysql/patches/patch-014-013.sql
@@ -1,0 +1,5 @@
+--  (commented out to avoid accidentally running this in production...)
+
+-- ALTER TABLE clients DROP COLUMN hashedSecretPrevious;
+
+-- UPDATE dbMetadata SET value = '13' WHERE name = 'schema-patch-level';

--- a/lib/db/mysql/schema.sql
+++ b/lib/db/mysql/schema.sql
@@ -10,6 +10,7 @@
 CREATE TABLE IF NOT EXISTS clients (
   id BINARY(8) PRIMARY KEY,
   hashedSecret BINARY(32),
+  hashedSecretPrevious BINARY(32),
   name VARCHAR(256) NOT NULL,
   imageUri VARCHAR(256) NOT NULL,
   redirectUri VARCHAR(256) NOT NULL,

--- a/lib/routes/token.js
+++ b/lib/routes/token.js
@@ -181,11 +181,23 @@ function confirmClient(id, secret) {
 
     var submitted = hex(encrypt.hash(buf(secret)));
     var stored = hex(client.hashedSecret);
+
     if (submitted !== stored) {
+      var storedPrevious;
+      if (client.hashedSecretPrevious) {
+        // Check if secret used is the current previous secret
+        storedPrevious = hex(client.hashedSecretPrevious);
+        if (submitted === storedPrevious) {
+          logger.info('client.matchSecretPrevious', { client: id });
+          return client;
+        }
+      }
+
       logger.info('client.mismatchSecret', { client: id });
       logger.verbose('client.mismatchSecret.details', {
         submitted: submitted,
-        db: stored
+        db: stored,
+        dbPrevious: storedPrevious
       });
       throw AppError.incorrectSecret(id);
     }


### PR DESCRIPTION
This PR adds initial support for changing a client's secret key with no downtime. Adds a new database column `hashSecretPrevious` and updated logic in `/token` route to check if client using previous key.

Fixes #317 