### PR TITLE
chore(dependencies): upgrade mozlog to 2.0.3

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,27 +4,27 @@
   "dependencies": {
     "blanket": {
       "version": "1.1.6",
-      "from": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
+      "from": "blanket@1.1.6",
       "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
       "dependencies": {
         "esprima": {
           "version": "1.0.4",
-          "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "from": "esprima@>=1.0.2 <1.1.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
         },
         "falafel": {
           "version": "0.1.6",
-          "from": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz",
+          "from": "falafel@>=0.1.6 <0.2.0",
           "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
         },
         "xtend": {
           "version": "2.1.2",
-          "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "from": "xtend@>=2.1.1 <2.2.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "dependencies": {
             "object-keys": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+              "from": "object-keys@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
             }
           }
@@ -33,57 +33,57 @@
     },
     "bluebird": {
       "version": "2.10.2",
-      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+      "from": "bluebird@>=2.9.14 <3.0.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
     },
     "buf": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/buf/-/buf-0.1.0.tgz",
+      "from": "buf@0.1.0",
       "resolved": "https://registry.npmjs.org/buf/-/buf-0.1.0.tgz"
     },
     "convict": {
       "version": "0.8.2",
-      "from": "https://registry.npmjs.org/convict/-/convict-0.8.2.tgz",
+      "from": "convict@>=0.8.0 <0.9.0",
       "resolved": "https://registry.npmjs.org/convict/-/convict-0.8.2.tgz",
       "dependencies": {
         "cjson": {
           "version": "0.3.1",
-          "from": "https://registry.npmjs.org/cjson/-/cjson-0.3.1.tgz",
+          "from": "cjson@0.3.1",
           "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.1.tgz",
           "dependencies": {
             "jsonlint": {
               "version": "1.6.0",
-              "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+              "from": "jsonlint@1.6.0",
               "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+                  "from": "nomnom@>=1.5.0",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                      "from": "underscore@>=1.6.0 <1.7.0",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                      "from": "chalk@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                          "from": "has-color@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                          "from": "ansi-styles@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                          "from": "strip-ansi@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -92,7 +92,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+                  "from": "JSV@>=4.0.0",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -101,54 +101,54 @@
         },
         "depd": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+          "from": "depd@1.0.1",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
         },
         "moment": {
           "version": "2.10.3",
-          "from": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz",
+          "from": "moment@2.10.3",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "from": "optimist@0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "validator": {
           "version": "3.40.0",
-          "from": "https://registry.npmjs.org/validator/-/validator-3.40.0.tgz",
+          "from": "validator@3.40.0",
           "resolved": "https://registry.npmjs.org/validator/-/validator-3.40.0.tgz"
         },
         "varify": {
           "version": "0.1.1",
-          "from": "https://registry.npmjs.org/varify/-/varify-0.1.1.tgz",
+          "from": "varify@0.1.1",
           "resolved": "https://registry.npmjs.org/varify/-/varify-0.1.1.tgz",
           "dependencies": {
             "through": {
               "version": "2.3.8",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "from": "through@>=2.3.4 <2.4.0",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             },
             "redeyed": {
               "version": "0.4.4",
-              "from": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+              "from": "redeyed@>=0.4.2 <0.5.0",
               "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
               "dependencies": {
                 "esprima": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+                  "from": "esprima@>=1.0.4 <1.1.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                 }
               }
@@ -159,32 +159,32 @@
     },
     "eslint-config-fxa": {
       "version": "1.8.1",
-      "from": "https://registry.npmjs.org/eslint-config-fxa/-/eslint-config-fxa-1.8.1.tgz",
+      "from": "eslint-config-fxa@>=1.8.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-fxa/-/eslint-config-fxa-1.8.1.tgz"
     },
     "fxa-jwtool": {
-      "version": "0.7.1",
-      "from": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.7.1.tgz",
-      "resolved": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.7.1.tgz",
+      "version": "0.7.2",
+      "from": "fxa-jwtool@>=0.7.1 <0.8.0",
+      "resolved": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.7.2.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "2.9.15",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.15.tgz",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.15.tgz"
+          "version": "3.0.5",
+          "from": "bluebird@3.0.5",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.0.5.tgz"
         },
         "fetch": {
           "version": "0.3.6",
-          "from": "https://registry.npmjs.org/fetch/-/fetch-0.3.6.tgz",
+          "from": "fetch@0.3.6",
           "resolved": "https://registry.npmjs.org/fetch/-/fetch-0.3.6.tgz",
           "dependencies": {
             "encoding": {
-              "version": "0.1.11",
-              "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
-              "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
+              "version": "0.1.12",
+              "from": "encoding@*",
+              "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
               "dependencies": {
                 "iconv-lite": {
                   "version": "0.4.13",
-                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                  "from": "iconv-lite@>=0.4.13 <0.5.0",
                   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                 }
               }
@@ -193,27 +193,27 @@
         },
         "pem-jwk": {
           "version": "1.5.1",
-          "from": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.5.1.tgz",
+          "from": "pem-jwk@1.5.1",
           "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.5.1.tgz",
           "dependencies": {
             "asn1.js": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+              "from": "asn1.js@1.0.3",
               "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimalistic-assert": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                  "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                 },
                 "bn.js": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
+                  "from": "bn.js@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 }
               }
@@ -224,29 +224,29 @@
     },
     "fxa-notifier-aws": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/fxa-notifier-aws/-/fxa-notifier-aws-1.0.0.tgz",
+      "from": "fxa-notifier-aws@1.0.0",
       "resolved": "https://registry.npmjs.org/fxa-notifier-aws/-/fxa-notifier-aws-1.0.0.tgz",
       "dependencies": {
         "aws-sdk": {
           "version": "2.0.23",
-          "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.23.tgz",
+          "from": "aws-sdk@2.0.23",
           "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.23.tgz",
           "dependencies": {
             "xml2js": {
               "version": "0.2.6",
-              "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
+              "from": "xml2js@0.2.6",
               "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
               "dependencies": {
                 "sax": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
+                  "from": "sax@0.4.2",
                   "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz"
                 }
               }
             },
             "xmlbuilder": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
+              "from": "xmlbuilder@0.4.2",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
             }
           }
@@ -259,70 +259,70 @@
       "resolved": "git://github.com/jrgm/node-generate-rsa-keypair.git#dce3504e0376920ebb4851eea42a3ee8cefa5a3f",
       "dependencies": {
         "nan": {
-          "version": "2.1.0",
-          "from": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
+          "version": "2.2.0",
+          "from": "nan@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
         }
       }
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "from": "grunt@>=0.4.5 <0.5.0",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "from": "async@>=0.1.22 <0.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
-          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+          "from": "dateformat@1.0.2-1.2.3",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+          "from": "eventemitter2@0.4.14",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@0.1.3",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.7.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                      "version": "2.7.3",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -331,149 +331,149 @@
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+              "from": "inherits@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "from": "minimatch@>=0.2.12 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.7.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+              "version": "2.7.3",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "from": "rimraf@>=2.2.8 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "from": "lodash@>=0.9.2 <0.10.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+          "from": "underscore.string@2.2.1",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.9",
-          "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+          "from": "which@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "from": "exit@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+          "from": "getobject@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+          "from": "grunt-legacy-util@0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
-          "version": "0.1.2",
-          "from": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
+          "version": "0.1.3",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
           "dependencies": {
             "grunt-legacy-log-utils": {
               "version": "0.1.1",
-              "from": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+              "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+              "from": "underscore.string@2.3.3",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -482,61 +482,61 @@
     },
     "grunt-bump": {
       "version": "0.3.1",
-      "from": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.3.1.tgz",
+      "from": "grunt-bump@0.3.1",
       "resolved": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.3.1.tgz",
       "dependencies": {
         "semver": {
           "version": "4.3.6",
-          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "from": "semver@>=4.3.3 <5.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "grunt-cli": {
       "version": "0.1.13",
-      "from": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "from": "grunt-cli@>=0.1.13 <0.2.0",
       "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+              "from": "abbrev@1.0.7",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@0.1.3",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.7.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                      "version": "2.7.3",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -545,128 +545,152 @@
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
         "resolve": {
           "version": "0.3.1",
-          "from": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+          "from": "resolve@>=0.3.1 <0.4.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
         }
       }
     },
     "grunt-conventional-changelog": {
       "version": "1.2.2",
-      "from": "https://registry.npmjs.org/grunt-conventional-changelog/-/grunt-conventional-changelog-1.2.2.tgz",
+      "from": "grunt-conventional-changelog@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/grunt-conventional-changelog/-/grunt-conventional-changelog-1.2.2.tgz",
       "dependencies": {
         "conventional-changelog": {
           "version": "0.0.17",
-          "from": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.0.17.tgz",
+          "from": "conventional-changelog@0.0.17",
           "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.0.17.tgz",
           "dependencies": {
             "dateformat": {
-              "version": "1.0.11",
-              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
-              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+              "version": "1.0.12",
+              "from": "dateformat@>=1.0.11 <2.0.0",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
               "dependencies": {
                 "get-stdin": {
-                  "version": "5.0.0",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.0.tgz"
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
-                  "version": "3.4.2",
-                  "from": "https://registry.npmjs.org/meow/-/meow-3.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.4.2.tgz",
+                  "version": "3.7.0",
+                  "from": "meow@>=3.3.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "version": "2.0.0",
+                      "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "1.2.1",
-                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                        },
-                        "map-obj": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                          "version": "2.1.0",
+                          "from": "camelcase@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.1.2",
+                      "from": "decamelize@>=1.1.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+                      "dependencies": {
+                        "escape-string-regexp": {
+                          "version": "1.0.4",
+                          "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                         }
                       }
                     },
                     "loud-rejection": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz"
+                      "version": "1.2.1",
+                      "from": "loud-rejection@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.1.tgz",
+                      "dependencies": {
+                        "array-find-index": {
+                          "version": "1.0.1",
+                          "from": "array-find-index@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
+                        },
+                        "signal-exit": {
+                          "version": "2.1.2",
+                          "from": "signal-exit@>=2.1.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+                        }
+                      }
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     },
                     "minimist": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                      "from": "minimist@>=1.1.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                     },
                     "normalize-package-data": {
-                      "version": "2.3.4",
-                      "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.4.tgz",
-                      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.4.tgz",
+                      "version": "2.3.5",
+                      "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.1.4",
-                          "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+                          "from": "hosted-git-info@>=2.1.4 <3.0.0",
                           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                         },
                         "is-builtin-module": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                          "from": "is-builtin-module@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                           "dependencies": {
                             "builtin-modules": {
-                              "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
+                              "version": "1.1.1",
+                              "from": "builtin-modules@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                             }
                           }
                         },
                         "semver": {
-                          "version": "5.0.3",
-                          "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+                          "version": "5.1.0",
+                          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                         },
                         "validate-npm-package-license": {
                           "version": "3.0.1",
-                          "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
                           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                           "dependencies": {
                             "spdx-correct": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.1.tgz",
+                              "version": "1.0.2",
+                              "from": "spdx-correct@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                               "dependencies": {
                                 "spdx-license-ids": {
-                                  "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz"
+                                  "version": "1.2.0",
+                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                                 }
                               }
                             },
                             "spdx-expression-parse": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
+                              "version": "1.0.2",
+                              "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                               "dependencies": {
                                 "spdx-exceptions": {
-                                  "version": "1.0.3",
-                                  "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz"
+                                  "version": "1.0.4",
+                                  "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                                 },
                                 "spdx-license-ids": {
-                                  "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz"
+                                  "version": "1.2.0",
+                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                                 }
                               }
                             }
@@ -676,33 +700,33 @@
                     },
                     "object-assign": {
                       "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+                      "from": "object-assign@>=4.0.1 <5.0.0",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                     },
                     "read-pkg-up": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                      "from": "read-pkg-up@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                       "dependencies": {
                         "find-up": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
+                          "version": "1.1.0",
+                          "from": "find-up@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
                           "dependencies": {
                             "path-exists": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz"
+                              "version": "2.1.0",
+                              "from": "path-exists@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                             },
                             "pinkie-promise": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                              "version": "2.0.0",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                  "version": "2.0.4",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
                             }
@@ -710,86 +734,93 @@
                         },
                         "read-pkg": {
                           "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                          "from": "read-pkg@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                           "dependencies": {
                             "load-json-file": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
+                              "version": "1.1.0",
+                              "from": "load-json-file@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "4.1.2",
-                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                  "version": "4.1.3",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                                 },
                                 "parse-json": {
                                   "version": "2.2.0",
-                                  "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                                  "from": "parse-json@>=2.2.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                   "dependencies": {
                                     "error-ex": {
-                                      "version": "1.2.0",
-                                      "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.2.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.2.0.tgz"
+                                      "version": "1.3.0",
+                                      "from": "error-ex@>=1.2.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                      "dependencies": {
+                                        "is-arrayish": {
+                                          "version": "0.2.1",
+                                          "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                        }
+                                      }
                                     }
                                   }
                                 },
                                 "pify": {
-                                  "version": "2.2.0",
-                                  "from": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz"
+                                  "version": "2.3.0",
+                                  "from": "pify@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                 },
                                 "pinkie-promise": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                                  "version": "2.0.0",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
-                                      "version": "1.0.0",
-                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                      "version": "2.0.4",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                     }
                                   }
                                 },
                                 "strip-bom": {
                                   "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                                  "from": "strip-bom@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                   "dependencies": {
                                     "is-utf8": {
-                                      "version": "0.2.0",
-                                      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                                      "version": "0.2.1",
+                                      "from": "is-utf8@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                                     }
                                   }
                                 }
                               }
                             },
                             "path-type": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
+                              "version": "1.1.0",
+                              "from": "path-type@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "4.1.2",
-                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                  "version": "4.1.3",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                                 },
                                 "pify": {
-                                  "version": "2.2.0",
-                                  "from": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz"
+                                  "version": "2.3.0",
+                                  "from": "pify@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                 },
                                 "pinkie-promise": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                                  "version": "2.0.0",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
-                                      "version": "1.0.0",
-                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                      "version": "2.0.4",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                     }
                                   }
                                 }
@@ -801,27 +832,27 @@
                     },
                     "redent": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                      "from": "redent@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                       "dependencies": {
                         "indent-string": {
                           "version": "2.1.0",
-                          "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                          "from": "indent-string@>=2.1.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                           "dependencies": {
                             "repeating": {
                               "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                              "from": "repeating@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "from": "is-finite@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
-                                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                     }
                                   }
@@ -832,21 +863,14 @@
                         },
                         "strip-indent": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-                          "dependencies": {
-                            "get-stdin": {
-                              "version": "4.0.1",
-                              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                            }
-                          }
+                          "from": "strip-indent@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                         }
                       }
                     },
                     "trim-newlines": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                      "from": "trim-newlines@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                     }
                   }
@@ -855,69 +879,69 @@
             },
             "event-stream": {
               "version": "3.3.2",
-              "from": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
+              "from": "event-stream@>=3.3.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
               "dependencies": {
                 "through": {
                   "version": "2.3.8",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "from": "through@>=2.3.1 <2.4.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 },
                 "duplexer": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+                  "from": "duplexer@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                 },
                 "from": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
+                  "from": "from@>=0.0.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
                 },
                 "map-stream": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+                  "from": "map-stream@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
                 },
                 "pause-stream": {
                   "version": "0.0.11",
-                  "from": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+                  "from": "pause-stream@0.0.11",
                   "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
                 },
                 "split": {
                   "version": "0.3.3",
-                  "from": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+                  "from": "split@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
                 },
                 "stream-combiner": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                  "from": "stream-combiner@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
                 }
               }
             },
             "github-url-from-git": {
               "version": "1.4.0",
-              "from": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
+              "from": "github-url-from-git@>=1.4.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz"
             },
             "lodash": {
               "version": "3.10.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "from": "lodash@>=3.6.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "normalize-package-data": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-1.0.3.tgz",
+              "from": "normalize-package-data@>=1.0.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-1.0.3.tgz",
               "dependencies": {
                 "github-url-from-username-repo": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
+                  "from": "github-url-from-username-repo@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz"
                 },
                 "semver": {
                   "version": "4.3.6",
-                  "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                 }
               }
@@ -928,108 +952,108 @@
     },
     "grunt-copyright": {
       "version": "0.2.0",
-      "from": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.2.0.tgz",
+      "from": "grunt-copyright@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.2.0.tgz"
     },
     "grunt-eslint": {
       "version": "16.0.0",
-      "from": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-16.0.0.tgz",
+      "from": "grunt-eslint@>=16.0.0 <17.0.0",
       "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-16.0.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "version": "1.0.4",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "from": "has-ansi@2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "from": "strip-ansi@3.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "eslint": {
           "version": "0.24.1",
-          "from": "https://registry.npmjs.org/eslint/-/eslint-0.24.1.tgz",
+          "from": "eslint@>=0.24.0 <0.25.0",
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.24.1.tgz",
           "dependencies": {
             "concat-stream": {
               "version": "1.5.1",
-              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+              "from": "concat-stream@>=1.4.6 <2.0.0",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
-                  "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                  "version": "2.0.5",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                      "version": "1.0.6",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -1038,286 +1062,271 @@
             },
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "from": "debug@>=2.1.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "doctrine": {
               "version": "0.6.4",
-              "from": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
+              "from": "doctrine@>=0.6.2 <0.7.0",
               "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "1.1.6",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+                  "from": "esutils@>=1.1.6 <2.0.0",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 }
               }
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "version": "1.0.4",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
             },
             "escope": {
-              "version": "3.2.0",
-              "from": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
+              "version": "3.4.0",
+              "from": "escope@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/escope/-/escope-3.4.0.tgz",
               "dependencies": {
                 "es6-map": {
-                  "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.2.tgz",
+                  "version": "0.1.3",
+                  "from": "es6-map@>=0.1.3 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                      "from": "d@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
-                      "version": "0.10.8",
-                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz"
+                      "version": "0.10.11",
+                      "from": "es5-ext@>=0.10.8 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
                     },
                     "es6-iterator": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+                      "from": "es6-iterator@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
                     },
                     "es6-set": {
-                      "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.2.tgz"
+                      "version": "0.1.4",
+                      "from": "es6-set@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
                     },
                     "es6-symbol": {
-                      "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz"
+                      "version": "3.0.2",
+                      "from": "es6-symbol@>=3.0.1 <3.1.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                     },
                     "event-emitter": {
                       "version": "0.3.4",
-                      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
+                      "from": "event-emitter@>=0.3.4 <0.4.0",
                       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
                     }
                   }
                 },
                 "es6-weak-map": {
-                  "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+                  "version": "2.0.1",
+                  "from": "es6-weak-map@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                      "from": "d@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
-                      "version": "0.10.8",
-                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
-                      "dependencies": {
-                        "es6-iterator": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
-                        },
-                        "es6-symbol": {
-                          "version": "3.0.0",
-                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz"
-                        }
-                      }
+                      "version": "0.10.11",
+                      "from": "es5-ext@>=0.10.8 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
                     },
                     "es6-iterator": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                      "version": "2.0.0",
+                      "from": "es6-iterator@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
                     },
                     "es6-symbol": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                      "version": "3.0.2",
+                      "from": "es6-symbol@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                     }
                   }
                 },
                 "esrecurse": {
                   "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
-                },
-                "estraverse": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
+                  "from": "esrecurse@>=3.1.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
+                  "dependencies": {
+                    "estraverse": {
+                      "version": "3.1.0",
+                      "from": "estraverse@>=3.1.0 <3.2.0",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
+                    }
+                  }
                 }
               }
             },
             "espree": {
               "version": "2.2.5",
-              "from": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
+              "from": "espree@2.2.5",
               "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
             },
             "estraverse": {
               "version": "4.1.1",
-              "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+              "from": "estraverse@4.1.1",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
             },
             "estraverse-fb": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
+              "from": "estraverse-fb@>=1.3.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
             },
             "globals": {
-              "version": "8.11.0",
-              "from": "https://registry.npmjs.org/globals/-/globals-8.11.0.tgz",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-8.11.0.tgz"
+              "version": "8.18.0",
+              "from": "globals@>=8.0.0 <9.0.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
             },
             "inquirer": {
               "version": "0.8.5",
-              "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
+              "from": "inquirer@>=0.8.2 <0.9.0",
               "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                  "from": "ansi-regex@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "cli-width": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz"
+                  "version": "1.1.1",
+                  "from": "cli-width@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz"
                 },
                 "figures": {
                   "version": "1.4.0",
-                  "from": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz",
+                  "from": "figures@>=1.3.5 <2.0.0",
                   "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                  "from": "lodash@>=3.3.1 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "readline2": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+                  "from": "readline2@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
                   "dependencies": {
                     "mute-stream": {
                       "version": "0.0.4",
-                      "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+                      "from": "mute-stream@0.0.4",
                       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
                     },
                     "strip-ansi": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                      "from": "strip-ansi@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
                     }
                   }
                 },
                 "rx": {
                   "version": "2.5.3",
-                  "from": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
+                  "from": "rx@>=2.4.3 <3.0.0",
                   "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "from": "through@>=2.3.6 <3.0.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "is-my-json-valid": {
-              "version": "2.12.2",
-              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+              "version": "2.12.4",
+              "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                  "from": "generate-function@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                  "from": "generate-object-property@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                      "from": "is-property@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                  "from": "jsonpointer@2.0.0",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                 },
                 "xtend": {
-                  "version": "4.0.0",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "js-yaml": {
-              "version": "3.4.3",
-              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
+              "version": "3.5.3",
+              "from": "js-yaml@>=3.2.5 <4.0.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.3.tgz",
               "dependencies": {
                 "argparse": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "version": "1.0.6",
+                  "from": "argparse@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.6.tgz",
                   "dependencies": {
-                    "lodash": {
-                      "version": "3.10.1",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                    },
                     "sprintf-js": {
                       "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                     }
                   }
                 },
                 "esprima": {
-                  "version": "2.6.0",
-                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz"
+                  "version": "2.7.2",
+                  "from": "esprima@>=2.6.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "from": "minimatch@2.0.10",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                  "version": "1.1.3",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                      "version": "0.3.0",
+                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -1326,81 +1335,81 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "object-assign": {
               "version": "2.1.1",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+              "from": "object-assign@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
             },
             "optionator": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+              "from": "optionator@0.5.0",
               "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
               "dependencies": {
                 "prelude-ls": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                  "from": "prelude-ls@>=1.1.1 <1.2.0",
                   "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                 },
                 "deep-is": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                  "from": "deep-is@>=0.1.2 <0.2.0",
                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 },
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 },
                 "type-check": {
-                  "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                  "version": "0.3.2",
+                  "from": "type-check@>=0.3.1 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
                 },
                 "levn": {
                   "version": "0.2.5",
-                  "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                  "from": "levn@>=0.2.5 <0.3.0",
                   "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                 },
                 "fast-levenshtein": {
                   "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+                  "from": "fast-levenshtein@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+              "from": "strip-json-comments@1.0.4",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
             },
             "text-table": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+              "from": "text-table@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
             },
             "user-home": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+              "from": "user-home@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             },
             "xml-escape": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
+              "from": "xml-escape@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
             }
           }
@@ -1409,181 +1418,181 @@
     },
     "grunt-jscs": {
       "version": "1.8.0",
-      "from": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.8.0.tgz",
+      "from": "grunt-jscs@>=1.5.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.8.0.tgz",
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "jscs": {
           "version": "1.13.1",
-          "from": "https://registry.npmjs.org/jscs/-/jscs-1.13.1.tgz",
+          "from": "jscs@>=1.13.0 <1.14.0",
           "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.13.1.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+              "from": "chalk@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                  "from": "ansi-styles@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                  "version": "1.0.4",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                 },
                 "has-ansi": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "from": "has-ansi@>=1.0.3 <2.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                      "from": "ansi-regex@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     },
                     "get-stdin": {
                       "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
                       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+                  "from": "supports-color@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
                 }
               }
             },
             "cli-table": {
               "version": "0.3.1",
-              "from": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+              "from": "cli-table@>=0.3.1 <0.4.0",
               "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
               "dependencies": {
                 "colors": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+                  "from": "colors@1.0.3",
                   "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.6.0",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+              "from": "commander@>=2.6.0 <2.7.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
             },
             "esprima": {
               "version": "1.2.5",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+              "from": "esprima@>=1.2.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
             },
             "esprima-harmony-jscs": {
               "version": "1.1.0-bin",
-              "from": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-bin.tgz",
+              "from": "esprima-harmony-jscs@1.1.0-bin",
               "resolved": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-bin.tgz"
             },
             "estraverse": {
               "version": "1.9.3",
-              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+              "from": "estraverse@>=1.9.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
             },
             "exit": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+              "from": "exit@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "glob": {
               "version": "5.0.15",
-              "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "from": "glob@>=5.0.1 <6.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
-                  "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "version": "1.3.3",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
             "lodash.assign": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
+              "from": "lodash.assign@>=3.0.0 <3.1.0",
               "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
               "dependencies": {
                 "lodash._baseassign": {
                   "version": "3.2.0",
-                  "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                     },
                     "lodash.keys": {
                       "version": "3.1.2",
-                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "from": "lodash.keys@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                       "dependencies": {
                         "lodash._getnative": {
                           "version": "3.9.1",
-                          "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                         },
                         "lodash.isarguments": {
-                          "version": "3.0.4",
-                          "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                          "version": "3.0.6",
+                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.6.tgz"
                         },
                         "lodash.isarray": {
                           "version": "3.0.4",
-                          "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                         }
                       }
@@ -1592,22 +1601,22 @@
                 },
                 "lodash._createassigner": {
                   "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
                   "dependencies": {
                     "lodash._bindcallback": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                     },
                     "lodash._isiterateecall": {
                       "version": "3.0.9",
-                      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                     },
                     "lodash.restparam": {
                       "version": "3.6.1",
-                      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                     }
                   }
@@ -1616,22 +1625,22 @@
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "from": "minimatch@2.0.10",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                  "version": "1.1.3",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                      "version": "0.3.0",
+                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -1640,101 +1649,144 @@
             },
             "pathval": {
               "version": "0.1.1",
-              "from": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz",
+              "from": "pathval@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz"
             },
             "prompt": {
               "version": "0.2.14",
-              "from": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
+              "from": "prompt@>=0.2.14 <0.3.0",
               "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
               "dependencies": {
                 "pkginfo": {
-                  "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
+                  "version": "0.3.1",
+                  "from": "pkginfo@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
                 },
                 "revalidator": {
                   "version": "0.1.8",
-                  "from": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+                  "from": "revalidator@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
                 },
                 "utile": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+                  "from": "utile@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                      "from": "async@>=0.2.9 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "deep-equal": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+                      "from": "deep-equal@*",
                       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
                     },
                     "i": {
-                      "version": "0.3.3",
-                      "from": "https://registry.npmjs.org/i/-/i-0.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
+                      "version": "0.3.4",
+                      "from": "i@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/i/-/i-0.3.4.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "from": "mkdirp@>=0.0.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "from": "minimist@0.0.8",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "ncp": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+                      "from": "ncp@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                     },
                     "rimraf": {
-                      "version": "2.4.3",
-                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
+                      "version": "2.5.2",
+                      "from": "rimraf@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "7.0.0",
+                          "from": "glob@>=7.0.0 <8.0.0",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "inflight@>=1.0.4 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "once@>=1.3.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 },
                 "winston": {
                   "version": "0.8.3",
-                  "from": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+                  "from": "winston@>=0.8.0 <0.9.0",
                   "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                      "from": "async@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "colors": {
                       "version": "0.6.2",
-                      "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+                      "from": "colors@>=0.6.0 <0.7.0",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
                     },
                     "cycle": {
                       "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+                      "from": "cycle@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
                     },
                     "eyes": {
                       "version": "0.1.8",
-                      "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+                      "from": "eyes@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
                     },
                     "isstream": {
                       "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                      "from": "isstream@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                     },
                     "stack-trace": {
                       "version": "0.0.9",
-                      "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+                      "from": "stack-trace@>=0.0.0 <0.1.0",
                       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                     }
                   }
@@ -1743,54 +1795,54 @@
             },
             "strip-json-comments": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+              "from": "strip-json-comments@1.0.4",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
             },
             "vow-fs": {
               "version": "0.3.4",
-              "from": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
+              "from": "vow-fs@>=0.3.4 <0.4.0",
               "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
               "dependencies": {
                 "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                  "version": "1.4.7",
+                  "from": "node-uuid@>=1.4.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
                 "vow-queue": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz",
+                  "from": "vow-queue@>=0.4.1 <0.5.0",
                   "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz"
                 },
                 "glob": {
                   "version": "4.5.3",
-                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "from": "glob@>=4.3.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
-                      "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "version": "1.3.3",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -1801,12 +1853,12 @@
             },
             "xmlbuilder": {
               "version": "2.6.5",
-              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.5.tgz",
+              "from": "xmlbuilder@>=2.6.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.5.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                  "from": "lodash@>=3.5.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 }
               }
@@ -1815,34 +1867,34 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "vow": {
-          "version": "0.4.11",
-          "from": "https://registry.npmjs.org/vow/-/vow-0.4.11.tgz",
-          "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.11.tgz"
+          "version": "0.4.12",
+          "from": "vow@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.12.tgz"
         }
       }
     },
     "grunt-mocha-test": {
       "version": "0.12.7",
-      "from": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.12.7.tgz",
+      "from": "grunt-mocha-test@>=0.12.2 <0.13.0",
       "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.12.7.tgz",
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
@@ -1850,256 +1902,1353 @@
       }
     },
     "grunt-nodemon": {
-      "version": "0.4.0",
-      "from": "https://registry.npmjs.org/grunt-nodemon/-/grunt-nodemon-0.4.0.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-nodemon/-/grunt-nodemon-0.4.0.tgz",
+      "version": "0.4.1",
+      "from": "grunt-nodemon@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-nodemon/-/grunt-nodemon-0.4.1.tgz",
       "dependencies": {
         "nodemon": {
-          "version": "1.3.8",
-          "from": "https://registry.npmjs.org/nodemon/-/nodemon-1.3.8.tgz",
-          "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.3.8.tgz",
+          "version": "1.8.1",
+          "from": "nodemon@>=1.7.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.8.1.tgz",
           "dependencies": {
-            "minimatch": {
-              "version": "0.3.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+            "chokidar": {
+              "version": "1.4.2",
+              "from": "chokidar@>=1.2.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz",
               "dependencies": {
-                "lru-cache": {
-                  "version": "2.7.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                "anymatch": {
+                  "version": "1.3.0",
+                  "from": "anymatch@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                  "dependencies": {
+                    "arrify": {
+                      "version": "1.0.1",
+                      "from": "arrify@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                    },
+                    "micromatch": {
+                      "version": "2.3.7",
+                      "from": "micromatch@>=2.1.5 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
+                      "dependencies": {
+                        "arr-diff": {
+                          "version": "2.0.0",
+                          "from": "arr-diff@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                          "dependencies": {
+                            "arr-flatten": {
+                              "version": "1.0.1",
+                              "from": "arr-flatten@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "array-unique": {
+                          "version": "0.2.1",
+                          "from": "array-unique@>=0.2.1 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                        },
+                        "braces": {
+                          "version": "1.8.3",
+                          "from": "braces@>=1.8.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
+                          "dependencies": {
+                            "expand-range": {
+                              "version": "1.8.1",
+                              "from": "expand-range@>=1.8.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                              "dependencies": {
+                                "fill-range": {
+                                  "version": "2.2.3",
+                                  "from": "fill-range@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                                  "dependencies": {
+                                    "is-number": {
+                                      "version": "2.1.0",
+                                      "from": "is-number@>=2.1.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                    },
+                                    "isobject": {
+                                      "version": "2.0.0",
+                                      "from": "isobject@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
+                                      "dependencies": {
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "randomatic": {
+                                      "version": "1.1.5",
+                                      "from": "randomatic@>=1.1.3 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "preserve": {
+                              "version": "0.2.0",
+                              "from": "preserve@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                            },
+                            "repeat-element": {
+                              "version": "1.1.2",
+                              "from": "repeat-element@>=1.1.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                            }
+                          }
+                        },
+                        "expand-brackets": {
+                          "version": "0.1.4",
+                          "from": "expand-brackets@>=0.1.4 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+                        },
+                        "extglob": {
+                          "version": "0.3.2",
+                          "from": "extglob@>=0.3.1 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                        },
+                        "filename-regex": {
+                          "version": "2.0.0",
+                          "from": "filename-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                        },
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        },
+                        "kind-of": {
+                          "version": "3.0.2",
+                          "from": "kind-of@>=3.0.2 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                          "dependencies": {
+                            "is-buffer": {
+                              "version": "1.1.2",
+                              "from": "is-buffer@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                            }
+                          }
+                        },
+                        "normalize-path": {
+                          "version": "2.0.1",
+                          "from": "normalize-path@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                        },
+                        "object.omit": {
+                          "version": "2.0.0",
+                          "from": "object.omit@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
+                          "dependencies": {
+                            "for-own": {
+                              "version": "0.1.3",
+                              "from": "for-own@>=0.1.3 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                              "dependencies": {
+                                "for-in": {
+                                  "version": "0.1.4",
+                                  "from": "for-in@>=0.1.4 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                }
+                              }
+                            },
+                            "is-extendable": {
+                              "version": "0.1.1",
+                              "from": "is-extendable@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                            }
+                          }
+                        },
+                        "parse-glob": {
+                          "version": "3.0.4",
+                          "from": "parse-glob@>=3.0.4 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                          "dependencies": {
+                            "glob-base": {
+                              "version": "0.3.0",
+                              "from": "glob-base@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                            },
+                            "is-dotfile": {
+                              "version": "1.0.2",
+                              "from": "is-dotfile@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "regex-cache": {
+                          "version": "0.4.2",
+                          "from": "regex-cache@>=0.4.2 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                          "dependencies": {
+                            "is-equal-shallow": {
+                              "version": "0.1.3",
+                              "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                            },
+                            "is-primitive": {
+                              "version": "2.0.0",
+                              "from": "is-primitive@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 },
-                "sigmund": {
+                "async-each": {
+                  "version": "0.1.6",
+                  "from": "async-each@>=0.1.6 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                },
+                "glob-parent": {
+                  "version": "2.0.0",
+                  "from": "glob-parent@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "is-binary-path": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                  "from": "is-binary-path@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                  "dependencies": {
+                    "binary-extensions": {
+                      "version": "1.4.0",
+                      "from": "binary-extensions@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
+                    }
+                  }
+                },
+                "is-glob": {
+                  "version": "2.0.1",
+                  "from": "is-glob@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                  "dependencies": {
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                },
+                "readdirp": {
+                  "version": "2.0.0",
+                  "from": "readdirp@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.3",
+                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "from": "minimatch@>=2.0.10 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "2.0.5",
+                      "from": "readable-stream@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "fsevents": {
+                  "version": "1.0.7",
+                  "from": "fsevents@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.7.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "2.2.0",
+                      "from": "nan@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
+                    },
+                    "node-pre-gyp": {
+                      "version": "0.6.19",
+                      "from": "node-pre-gyp@>=0.6.17 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.19.tgz",
+                      "dependencies": {
+                        "nopt": {
+                          "version": "3.0.6",
+                          "from": "nopt@~3.0.1",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                          "dependencies": {
+                            "abbrev": {
+                              "version": "1.0.7",
+                              "from": "abbrev@1",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ansi": {
+                      "version": "0.3.0",
+                      "from": "ansi@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                    },
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    },
+                    "ansi-styles": {
+                      "version": "2.1.0",
+                      "from": "ansi-styles@^2.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                    },
+                    "are-we-there-yet": {
+                      "version": "1.0.5",
+                      "from": "are-we-there-yet@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@^0.1.5",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "async": {
+                      "version": "1.5.1",
+                      "from": "async@^1.4.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.1.tgz"
+                    },
+                    "aws-sign2": {
+                      "version": "0.6.0",
+                      "from": "aws-sign2@~0.6.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                    },
+                    "bl": {
+                      "version": "1.0.0",
+                      "from": "bl@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                    },
+                    "block-stream": {
+                      "version": "0.0.8",
+                      "from": "block-stream@*",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                    },
+                    "boom": {
+                      "version": "2.10.1",
+                      "from": "boom@2.x.x",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    },
+                    "caseless": {
+                      "version": "0.11.0",
+                      "from": "caseless@~0.11.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                    },
+                    "chalk": {
+                      "version": "1.1.1",
+                      "from": "chalk@^1.1.1",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "from": "combined-stream@~1.0.5",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+                    },
+                    "commander": {
+                      "version": "2.9.0",
+                      "from": "commander@^2.9.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@2.x.x",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@~0.7.2",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "deep-extend": {
+                      "version": "0.4.0",
+                      "from": "deep-extend@~0.4.0",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
+                    },
+                    "dashdash": {
+                      "version": "1.11.0",
+                      "from": "dashdash@>=1.10.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.11.0.tgz"
+                    },
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                    },
+                    "delegates": {
+                      "version": "0.1.0",
+                      "from": "delegates@^0.1.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.4",
+                      "from": "escape-string-regexp@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "extend": {
+                      "version": "3.0.0",
+                      "from": "extend@~3.0.0",
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                    },
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "from": "forever-agent@~0.6.1",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    },
+                    "fstream": {
+                      "version": "1.0.8",
+                      "from": "fstream@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc3",
+                      "from": "form-data@~1.0.0-rc3",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+                    },
+                    "gauge": {
+                      "version": "1.2.2",
+                      "from": "gauge@~1.2.0",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
+                    },
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "generate-function@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "graceful-fs": {
+                      "version": "4.1.2",
+                      "from": "graceful-fs@^4.1.2",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "generate-object-property@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                    },
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>= 1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    },
+                    "har-validator": {
+                      "version": "2.0.3",
+                      "from": "har-validator@~2.0.2",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                    },
+                    "hawk": {
+                      "version": "3.1.2",
+                      "from": "hawk@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
+                    },
+                    "has-unicode": {
+                      "version": "1.0.1",
+                      "from": "has-unicode@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "hoek@2.x.x",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    },
+                    "http-signature": {
+                      "version": "1.1.0",
+                      "from": "http-signature@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@*",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "ini": {
+                      "version": "1.3.4",
+                      "from": "ini@~1.3.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.3",
+                      "from": "is-my-json-valid@^2.12.3",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
+                    },
+                    "is-property": {
+                      "version": "1.0.2",
+                      "from": "is-property@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "from": "is-typedarray@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "from": "isstream@~0.1.2",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    },
+                    "json-schema": {
+                      "version": "0.2.2",
+                      "from": "json-schema@0.2.2",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@~5.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0",
+                      "from": "jsonpointer@2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                    },
+                    "lodash._createpadding": {
+                      "version": "3.6.1",
+                      "from": "lodash._createpadding@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
+                    },
+                    "jsprim": {
+                      "version": "1.2.2",
+                      "from": "jsprim@^1.2.2",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+                    },
+                    "lodash._basetostring": {
+                      "version": "3.0.1",
+                      "from": "lodash._basetostring@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                    },
+                    "lodash.pad": {
+                      "version": "3.1.1",
+                      "from": "lodash.pad@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
+                    },
+                    "lodash.padleft": {
+                      "version": "3.1.1",
+                      "from": "lodash.padleft@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
+                    },
+                    "lodash.padright": {
+                      "version": "3.1.1",
+                      "from": "lodash.padright@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
+                    },
+                    "lodash.repeat": {
+                      "version": "3.0.1",
+                      "from": "lodash.repeat@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                    },
+                    "mime-db": {
+                      "version": "1.21.0",
+                      "from": "mime-db@~1.21.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.9",
+                      "from": "mime-types@~2.1.7",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.7",
+                      "from": "node-uuid@~1.4.7",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                    },
+                    "npmlog": {
+                      "version": "2.0.0",
+                      "from": "npmlog@~2.0.0",
+                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.0.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.0",
+                      "from": "oauth-sign@~0.8.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                    },
+                    "once": {
+                      "version": "1.1.1",
+                      "from": "once@~1.1.1",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                    },
+                    "pinkie": {
+                      "version": "2.0.1",
+                      "from": "pinkie@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.0",
+                      "from": "pinkie-promise@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6",
+                      "from": "process-nextick-args@~1.0.6",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                    },
+                    "qs": {
+                      "version": "5.2.0",
+                      "from": "qs@~5.2.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "2.0.5",
+                      "from": "readable-stream@^2.0.0 || ^1.1.13",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+                    },
+                    "request": {
+                      "version": "2.67.0",
+                      "from": "request@2.x",
+                      "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz"
+                    },
+                    "semver": {
+                      "version": "5.1.0",
+                      "from": "semver@~5.1.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@1.x.x",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "from": "stringstream@~0.0.4",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.0",
+                      "from": "strip-ansi@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "1.0.4",
+                      "from": "strip-json-comments@~1.0.4",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "supports-color@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    },
+                    "tar": {
+                      "version": "2.2.1",
+                      "from": "tar@~2.2.0",
+                      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "2.2.1",
+                      "from": "tough-cookie@~2.2.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.2",
+                      "from": "tunnel-agent@~0.4.1",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+                    },
+                    "tweetnacl": {
+                      "version": "0.13.2",
+                      "from": "tweetnacl@>=0.13.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
+                    },
+                    "uid-number": {
+                      "version": "0.0.3",
+                      "from": "uid-number@0.0.3",
+                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@~1.0.1",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "xtend@^4.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    },
+                    "rc": {
+                      "version": "1.1.6",
+                      "from": "rc@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@^1.2.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.7.2",
+                      "from": "sshpk@^1.7.0",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.2.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.2.0",
+                          "from": "assert-plus@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                        }
+                      }
+                    },
+                    "fstream-ignore": {
+                      "version": "1.0.3",
+                      "from": "fstream-ignore@~1.0.3",
+                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
+                      "dependencies": {
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "minimatch@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.2",
+                              "from": "brace-expansion@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "balanced-match@^0.3.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.5.0",
+                      "from": "rimraf@~2.5.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "6.0.3",
+                          "from": "glob@^6.0.1",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "inflight@^1.0.4",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@~2.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "minimatch@2 || 3",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.2",
+                                  "from": "brace-expansion@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0",
+                                      "from": "balanced-match@^0.3.0",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "concat-map@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "once@^1.3.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "path-is-absolute@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "tar-pack": {
+                      "version": "3.1.2",
+                      "from": "tar-pack@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.2.tgz",
+                      "dependencies": {
+                        "rimraf": {
+                          "version": "2.4.5",
+                          "from": "rimraf@~2.4.4",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                          "dependencies": {
+                            "glob": {
+                              "version": "6.0.3",
+                              "from": "glob@^6.0.1",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
+                              "dependencies": {
+                                "inflight": {
+                                  "version": "1.0.4",
+                                  "from": "inflight@^1.0.4",
+                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@1",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@2",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "minimatch": {
+                                  "version": "3.0.0",
+                                  "from": "minimatch@2 || 3",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                                  "dependencies": {
+                                    "brace-expansion": {
+                                      "version": "1.1.2",
+                                      "from": "brace-expansion@^1.0.0",
+                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                                      "dependencies": {
+                                        "balanced-match": {
+                                          "version": "0.3.0",
+                                          "from": "balanced-match@^0.3.0",
+                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                        },
+                                        "concat-map": {
+                                          "version": "0.0.1",
+                                          "from": "concat-map@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "once": {
+                                  "version": "1.3.3",
+                                  "from": "once@^1.3.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@1",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "path-is-absolute": {
+                                  "version": "1.0.0",
+                                  "from": "path-is-absolute@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.2.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "es6-promise": {
+              "version": "3.1.2",
+              "from": "es6-promise@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
+            },
+            "lodash.defaults": {
+              "version": "3.1.2",
+              "from": "lodash.defaults@>=3.1.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
+              "dependencies": {
+                "lodash.assign": {
+                  "version": "3.2.0",
+                  "from": "lodash.assign@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._baseassign": {
+                      "version": "3.2.0",
+                      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                      "dependencies": {
+                        "lodash._basecopy": {
+                          "version": "3.0.1",
+                          "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._createassigner": {
+                      "version": "3.1.1",
+                      "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                      "dependencies": {
+                        "lodash._bindcallback": {
+                          "version": "3.0.1",
+                          "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                        },
+                        "lodash._isiterateecall": {
+                          "version": "3.0.9",
+                          "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                        }
+                      }
+                    },
+                    "lodash.keys": {
+                      "version": "3.1.2",
+                      "from": "lodash.keys@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "dependencies": {
+                        "lodash._getnative": {
+                          "version": "3.9.1",
+                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                        },
+                        "lodash.isarguments": {
+                          "version": "3.0.6",
+                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.6.tgz"
+                        },
+                        "lodash.isarray": {
+                          "version": "3.0.4",
+                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "3.0.0",
+              "from": "minimatch@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.3",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0",
+                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
                 }
               }
             },
             "ps-tree": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/ps-tree/-/ps-tree-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-0.0.3.tgz",
+              "version": "1.0.1",
+              "from": "ps-tree@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.0.1.tgz",
               "dependencies": {
                 "event-stream": {
-                  "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz",
-                  "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz",
+                  "version": "3.3.2",
+                  "from": "event-stream@>=3.3.0 <3.4.0",
+                  "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
                   "dependencies": {
-                    "optimist": {
-                      "version": "0.2.8",
-                      "from": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
-                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
-                      "dependencies": {
-                        "wordwrap": {
-                          "version": "0.0.3",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                        }
-                      }
+                    "through": {
+                      "version": "2.3.8",
+                      "from": "through@>=2.3.1 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    },
+                    "duplexer": {
+                      "version": "0.1.1",
+                      "from": "duplexer@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                    },
+                    "from": {
+                      "version": "0.1.3",
+                      "from": "from@>=0.0.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
+                    },
+                    "map-stream": {
+                      "version": "0.1.0",
+                      "from": "map-stream@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+                    },
+                    "pause-stream": {
+                      "version": "0.0.11",
+                      "from": "pause-stream@0.0.11",
+                      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
+                    },
+                    "split": {
+                      "version": "0.3.3",
+                      "from": "split@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
+                    },
+                    "stream-combiner": {
+                      "version": "0.0.4",
+                      "from": "stream-combiner@>=0.0.4 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
                     }
                   }
                 }
               }
             },
             "touch": {
-              "version": "0.0.4",
-              "from": "https://registry.npmjs.org/touch/-/touch-0.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.4.tgz",
+              "version": "1.0.0",
+              "from": "touch@1.0.0",
+              "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
               "dependencies": {
                 "nopt": {
                   "version": "1.0.10",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+                  "from": "nopt@>=1.0.10 <1.1.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 }
               }
             },
+            "undefsafe": {
+              "version": "0.0.3",
+              "from": "undefsafe@0.0.3",
+              "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz"
+            },
             "update-notifier": {
-              "version": "0.3.2",
-              "from": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
+              "version": "0.5.0",
+              "from": "update-notifier@0.5.0",
+              "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.5.0.tgz",
               "dependencies": {
                 "chalk": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "from": "chalk@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                      "from": "ansi-styles@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                     },
                     "escape-string-regexp": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                      "version": "1.0.4",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "from": "has-ansi@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "from": "supports-color@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     }
                   }
                 },
                 "configstore": {
-                  "version": "0.3.2",
-                  "from": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+                  "version": "1.4.0",
+                  "from": "configstore@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
                   "dependencies": {
                     "graceful-fs": {
-                      "version": "3.0.8",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-                    },
-                    "js-yaml": {
-                      "version": "3.4.3",
-                      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
-                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
-                      "dependencies": {
-                        "argparse": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
-                          "dependencies": {
-                            "lodash": {
-                              "version": "3.10.1",
-                              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                            },
-                            "sprintf-js": {
-                              "version": "1.0.3",
-                              "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                            }
-                          }
-                        },
-                        "esprima": {
-                          "version": "2.6.0",
-                          "from": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz",
-                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz"
-                        }
-                      }
+                      "version": "4.1.3",
+                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "from": "mkdirp@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "from": "minimist@0.0.8",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "object-assign": {
-                      "version": "2.1.1",
-                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                      "version": "4.0.1",
+                      "from": "object-assign@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                    },
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                     },
                     "osenv": {
                       "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                      "from": "osenv@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                       "dependencies": {
                         "os-homedir": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                          "from": "os-homedir@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                        },
-                        "os-tmpdir": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                         }
                       }
                     },
-                    "user-home": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-                    },
                     "uuid": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+                      "from": "uuid@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
                     },
+                    "write-file-atomic": {
+                      "version": "1.1.4",
+                      "from": "write-file-atomic@>=1.1.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
+                      "dependencies": {
+                        "imurmurhash": {
+                          "version": "0.1.4",
+                          "from": "imurmurhash@>=0.1.4 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+                        },
+                        "slide": {
+                          "version": "1.1.6",
+                          "from": "slide@>=1.1.5 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+                        }
+                      }
+                    },
                     "xdg-basedir": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+                      "version": "2.0.0",
+                      "from": "xdg-basedir@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+                      "dependencies": {
+                        "os-homedir": {
+                          "version": "1.0.1",
+                          "from": "os-homedir@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                        }
+                      }
                     }
                   }
                 },
                 "is-npm": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+                  "from": "is-npm@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
                 },
                 "latest-version": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
+                  "from": "latest-version@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
                   "dependencies": {
                     "package-json": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
+                      "from": "package-json@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
                       "dependencies": {
                         "got": {
                           "version": "3.3.1",
-                          "from": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
+                          "from": "got@>=3.2.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
                           "dependencies": {
                             "duplexify": {
                               "version": "3.4.2",
-                              "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
+                              "from": "duplexify@>=3.2.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
                               "dependencies": {
                                 "end-of-stream": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                                  "from": "end-of-stream@1.0.0",
                                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                                   "dependencies": {
                                     "once": {
-                                      "version": "1.3.2",
-                                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                      "version": "1.3.3",
+                                      "from": "once@>=1.3.0 <1.4.0",
+                                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                                       "dependencies": {
                                         "wrappy": {
                                           "version": "1.0.1",
-                                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                          "from": "wrappy@>=1.0.0 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                         }
                                       }
@@ -2107,38 +3256,38 @@
                                   }
                                 },
                                 "readable-stream": {
-                                  "version": "2.0.2",
-                                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "version": "2.0.5",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                                   "dependencies": {
                                     "core-util-is": {
-                                      "version": "1.0.1",
-                                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                      "version": "1.0.2",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                                     },
                                     "inherits": {
                                       "version": "2.0.1",
-                                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     },
                                     "isarray": {
                                       "version": "0.0.1",
-                                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                      "from": "isarray@0.0.1",
                                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                     },
                                     "process-nextick-args": {
-                                      "version": "1.0.3",
-                                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
-                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                                      "version": "1.0.6",
+                                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
                                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                     },
                                     "util-deprecate": {
                                       "version": "1.0.2",
-                                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                                     }
                                   }
@@ -2147,96 +3296,96 @@
                             },
                             "infinity-agent": {
                               "version": "2.0.3",
-                              "from": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
+                              "from": "infinity-agent@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
                             },
                             "is-redirect": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+                              "from": "is-redirect@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
                             },
                             "is-stream": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz",
+                              "from": "is-stream@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
                             },
                             "lowercase-keys": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                              "from": "lowercase-keys@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
                             },
                             "nested-error-stacks": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
+                              "version": "1.0.2",
+                              "from": "nested-error-stacks@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
                               "dependencies": {
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
                             },
                             "object-assign": {
                               "version": "3.0.0",
-                              "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                              "from": "object-assign@>=3.0.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                             },
                             "prepend-http": {
                               "version": "1.0.3",
-                              "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
+                              "from": "prepend-http@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
                             },
                             "read-all-stream": {
-                              "version": "3.0.1",
-                              "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
+                              "version": "3.1.0",
+                              "from": "read-all-stream@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
                               "dependencies": {
                                 "pinkie-promise": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                                  "version": "2.0.0",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
-                                      "version": "1.0.0",
-                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                      "version": "2.0.4",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                     }
                                   }
                                 },
                                 "readable-stream": {
-                                  "version": "2.0.2",
-                                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "version": "2.0.5",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                                   "dependencies": {
                                     "core-util-is": {
-                                      "version": "1.0.1",
-                                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                      "version": "1.0.2",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                                     },
                                     "inherits": {
                                       "version": "2.0.1",
-                                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     },
                                     "isarray": {
                                       "version": "0.0.1",
-                                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                      "from": "isarray@0.0.1",
                                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                     },
                                     "process-nextick-args": {
-                                      "version": "1.0.3",
-                                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
-                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                                      "version": "1.0.6",
+                                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
                                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                     },
                                     "util-deprecate": {
                                       "version": "1.0.2",
-                                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                                     }
                                   }
@@ -2245,40 +3394,40 @@
                             },
                             "timed-out": {
                               "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
+                              "from": "timed-out@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
                             }
                           }
                         },
                         "registry-url": {
                           "version": "3.0.3",
-                          "from": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
+                          "from": "registry-url@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
                           "dependencies": {
                             "rc": {
-                              "version": "1.1.2",
-                              "from": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
-                              "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
+                              "version": "1.1.6",
+                              "from": "rc@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
                               "dependencies": {
-                                "minimist": {
-                                  "version": "1.2.0",
-                                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                                },
                                 "deep-extend": {
-                                  "version": "0.2.11",
-                                  "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
-                                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
-                                },
-                                "strip-json-comments": {
-                                  "version": "0.1.3",
-                                  "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                                  "version": "0.4.1",
+                                  "from": "deep-extend@>=0.4.0 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                                 },
                                 "ini": {
                                   "version": "1.3.4",
-                                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                                  "from": "ini@>=1.3.0 <1.4.0",
                                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                                },
+                                "minimist": {
+                                  "version": "1.2.0",
+                                  "from": "minimist@>=1.2.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                },
+                                "strip-json-comments": {
+                                  "version": "1.0.4",
+                                  "from": "strip-json-comments@>=1.0.4 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                                 }
                               }
                             }
@@ -2288,31 +3437,50 @@
                     }
                   }
                 },
+                "repeating": {
+                  "version": "1.1.3",
+                  "from": "repeating@>=1.1.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
                 "semver-diff": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
+                  "version": "2.1.0",
+                  "from": "semver-diff@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
                   "dependencies": {
                     "semver": {
-                      "version": "4.3.6",
-                      "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                      "version": "5.1.0",
+                      "from": "semver@>=5.0.3 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                     }
                   }
                 },
                 "string-length": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
+                  "from": "string-length@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
                   "dependencies": {
                     "strip-ansi": {
                       "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
@@ -2327,602 +3495,782 @@
     },
     "grunt-nsp": {
       "version": "2.1.2",
-      "from": "https://registry.npmjs.org/grunt-nsp/-/grunt-nsp-2.1.2.tgz",
+      "from": "grunt-nsp@2.1.2",
       "resolved": "https://registry.npmjs.org/grunt-nsp/-/grunt-nsp-2.1.2.tgz",
       "dependencies": {
         "nsp": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/nsp/-/nsp-2.0.1.tgz",
+          "from": "nsp@2.0.1",
           "resolved": "https://registry.npmjs.org/nsp/-/nsp-2.0.1.tgz",
           "dependencies": {
             "nodesecurity-npm-utils": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-3.0.0.tgz",
+              "from": "nodesecurity-npm-utils@3.0.0",
               "resolved": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-3.0.0.tgz"
-            },
-            "chalk": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
             },
             "cli-table": {
               "version": "0.3.1",
-              "from": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+              "from": "cli-table@0.3.1",
               "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz"
             },
             "https-proxy-agent": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+              "from": "https-proxy-agent@1.0.0",
               "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz"
             },
             "joi": {
               "version": "6.10.0",
-              "from": "https://registry.npmjs.org/joi/-/joi-6.10.0.tgz",
+              "from": "joi@6.10.0",
               "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.0.tgz"
             },
             "rc": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
+              "from": "rc@1.1.2",
               "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "from": "minimist@1.2.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 }
               }
             },
             "semver": {
               "version": "5.0.3",
-              "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+              "from": "semver@5.0.3",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
             },
             "subcommand": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/subcommand/-/subcommand-2.0.3.tgz",
+              "from": "subcommand@2.0.3",
               "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.0.3.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "from": "minimist@1.2.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 }
               }
             },
             "wreck": {
               "version": "6.3.0",
-              "from": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
+              "from": "wreck@6.3.0",
               "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz"
-            },
-            "agent-base": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz"
             },
             "ansi": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
+              "from": "ansi@0.3.0",
               "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
             },
-            "ansi-regex": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+            "agent-base": {
+              "version": "2.0.1",
+              "from": "agent-base@2.0.1",
+              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz"
             },
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            "asn1": {
+              "version": "0.1.11",
+              "from": "asn1@0.1.11",
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
-            "balanced-match": {
-              "version": "0.2.1",
-              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+            "assert-plus": {
+              "version": "0.1.5",
+              "from": "assert-plus@0.1.5",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+            },
+            "bl": {
+              "version": "1.0.0",
+              "from": "bl@1.0.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+            },
+            "aws-sign2": {
+              "version": "0.6.0",
+              "from": "aws-sign2@0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "boom": {
               "version": "2.10.1",
-              "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+              "from": "boom@2.10.1",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-            },
-            "brace-expansion": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz"
             },
             "builtin-modules": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
+              "from": "builtin-modules@1.1.0",
               "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
+            },
+            "caseless": {
+              "version": "0.11.0",
+              "from": "caseless@0.11.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "chownr": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/chownr/-/chownr-0.0.2.tgz",
+              "from": "chownr@0.0.2",
               "resolved": "https://registry.npmjs.org/chownr/-/chownr-0.0.2.tgz"
             },
             "cliclopts": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz",
+              "from": "cliclopts@1.1.1",
               "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz"
             },
             "colors": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+              "from": "colors@1.0.3",
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
             },
-            "concat-map": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "combined-stream@1.0.5",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
             },
-            "concat-stream": {
-              "version": "1.5.1",
-              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz"
+            "commander": {
+              "version": "2.9.0",
+              "from": "commander@2.9.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
             },
-            "core-util-is": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+            "cryptiles": {
+              "version": "2.0.5",
+              "from": "cryptiles@2.0.5",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
-            "debug": {
-              "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+            "ctype": {
+              "version": "0.5.3",
+              "from": "ctype@0.5.3",
+              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
             },
             "deep-extend": {
               "version": "0.2.11",
-              "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+              "from": "deep-extend@0.2.11",
               "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "from": "delayed-stream@1.0.0",
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
             },
             "delegates": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
+              "from": "delegates@0.1.0",
               "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "extend": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "from": "extend@3.0.0",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "from": "forever-agent@0.6.1",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+            },
+            "form-data": {
+              "version": "1.0.0-rc3",
+              "from": "form-data@1.0.0-rc3",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
             },
             "gauge": {
               "version": "1.2.2",
-              "from": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
+              "from": "gauge@1.2.2",
               "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
-            },
-            "glob": {
-              "version": "5.0.15",
-              "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
             },
             "graceful-fs": {
               "version": "3.0.8",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+              "from": "graceful-fs@3.0.8",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+            "graceful-readlink": {
+              "version": "1.0.1",
+              "from": "graceful-readlink@1.0.1",
+              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+            },
+            "har-validator": {
+              "version": "2.0.2",
+              "from": "har-validator@2.0.2",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz"
             },
             "has-unicode": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz",
+              "from": "has-unicode@1.0.1",
               "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+            },
+            "hawk": {
+              "version": "3.1.0",
+              "from": "hawk@3.1.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz"
             },
             "hoek": {
               "version": "2.16.3",
-              "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+              "from": "hoek@2.16.3",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
             "hosted-git-info": {
               "version": "2.1.4",
-              "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+              "from": "hosted-git-info@2.1.4",
               "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
             },
-            "inflight": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            "http-signature": {
+              "version": "0.11.0",
+              "from": "http-signature@0.11.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
             },
             "ini": {
               "version": "1.3.4",
-              "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "from": "ini@1.3.4",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
             },
             "is-builtin-module": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+              "from": "is-builtin-module@1.0.0",
               "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "from": "isarray@0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "isemail": {
               "version": "1.2.0",
-              "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+              "from": "isemail@1.2.0",
               "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@0.1.2",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "json-stringify-safe@5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "lodash._basetostring": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+              "from": "lodash._basetostring@3.0.1",
               "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
             },
             "lodash._createpadding": {
               "version": "3.6.1",
-              "from": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+              "from": "lodash._createpadding@3.6.1",
               "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
             },
             "lodash.pad": {
               "version": "3.1.1",
-              "from": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
+              "from": "lodash.pad@3.1.1",
               "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
             },
             "lodash.padleft": {
               "version": "3.1.1",
-              "from": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
+              "from": "lodash.padleft@3.1.1",
               "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
             },
             "lodash.padright": {
               "version": "3.1.1",
-              "from": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
+              "from": "lodash.padright@3.1.1",
               "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
             },
             "lodash.repeat": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
+              "from": "lodash.repeat@3.0.1",
               "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
             },
-            "minimatch": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
+            "mime-db": {
+              "version": "1.19.0",
+              "from": "mime-db@1.19.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
             },
-            "minimist": {
-              "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+            "mime-types": {
+              "version": "2.1.7",
+              "from": "mime-types@2.1.7",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
             },
             "moment": {
               "version": "2.10.6",
-              "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
+              "from": "moment@2.10.6",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
             },
-            "ms": {
-              "version": "0.7.1",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "node-uuid@1.4.3",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "normalize-package-data": {
               "version": "2.3.5",
-              "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+              "from": "normalize-package-data@2.3.5",
               "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
             },
             "npm-package-arg": {
               "version": "4.0.2",
-              "from": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.0.2.tgz",
+              "from": "npm-package-arg@4.0.2",
               "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.0.2.tgz"
+            },
+            "oauth-sign": {
+              "version": "0.8.0",
+              "from": "oauth-sign@0.8.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
             },
             "npmlog": {
               "version": "1.2.1",
-              "from": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+              "from": "npmlog@1.2.1",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
             },
-            "once": {
-              "version": "1.3.2",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
+            "qs": {
+              "version": "5.2.0",
+              "from": "qs@5.2.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
             },
-            "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-            },
-            "process-nextick-args": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
-            },
-            "readable-stream": {
-              "version": "2.0.4",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz"
+            "request": {
+              "version": "2.65.0",
+              "from": "request@2.65.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz"
             },
             "retry": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz",
+              "from": "retry@0.6.1",
               "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
-            },
-            "rimraf": {
-              "version": "2.4.3",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
             },
             "silent-npm-registry-client": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/silent-npm-registry-client/-/silent-npm-registry-client-1.0.0.tgz",
+              "from": "silent-npm-registry-client@1.0.0",
               "resolved": "https://registry.npmjs.org/silent-npm-registry-client/-/silent-npm-registry-client-1.0.0.tgz"
             },
             "slide": {
               "version": "1.1.6",
-              "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+              "from": "slide@1.1.6",
               "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
             },
-            "spdx-correct": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
+            "sntp": {
+              "version": "1.0.9",
+              "from": "sntp@1.0.9",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             },
             "spdx-exceptions": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz",
+              "from": "spdx-exceptions@1.0.3",
               "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz"
+            },
+            "spdx-correct": {
+              "version": "1.0.2",
+              "from": "spdx-correct@1.0.2",
+              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
             },
             "spdx-expression-parse": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
+              "from": "spdx-expression-parse@1.0.0",
               "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz"
             },
             "spdx-license-ids": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
+              "from": "spdx-license-ids@1.1.0",
               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
             },
-            "string_decoder": {
-              "version": "0.10.31",
-              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+            "stringstream": {
+              "version": "0.0.5",
+              "from": "stringstream@0.0.5",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "strip-json-comments": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+              "from": "strip-json-comments@0.1.3",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             },
             "topo": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+              "from": "topo@1.1.0",
               "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
             },
-            "typedarray": {
-              "version": "0.0.6",
-              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            "tough-cookie": {
+              "version": "2.2.0",
+              "from": "tough-cookie@2.2.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
             },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            "tunnel-agent": {
+              "version": "0.4.1",
+              "from": "tunnel-agent@0.4.1",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+              "from": "validate-npm-package-license@3.0.1",
               "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-            },
-            "wrappy": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "xtend@4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            },
-            "npm-registry-client": {
-              "version": "6.3.3",
-              "from": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-6.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-6.3.3.tgz",
-              "dependencies": {
-                "semver": {
-                  "version": "4.3.6",
-                  "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-                }
-              }
             },
             "are-we-there-yet": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+              "from": "are-we-there-yet@1.0.4",
               "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@1.1.13",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+                }
+              }
+            },
+            "npm-registry-client": {
+              "version": "6.3.3",
+              "from": "npm-registry-client@6.3.3",
+              "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-6.3.3.tgz",
+              "dependencies": {
+                "semver": {
+                  "version": "4.3.6",
+                  "from": "semver@4.3.6",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                 }
               }
             }
           }
+        },
+        "ansi-regex": {
+          "version": "2.0.0",
+          "from": "ansi-regex@2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+        },
+        "ansi-styles": {
+          "version": "2.1.0",
+          "from": "ansi-styles@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+        },
+        "async": {
+          "version": "1.5.0",
+          "from": "async@1.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+        },
+        "balanced-match": {
+          "version": "0.2.1",
+          "from": "balanced-match@0.2.1",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+        },
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+        },
+        "brace-expansion": {
+          "version": "1.1.1",
+          "from": "brace-expansion@1.1.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz"
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "from": "concat-map@0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+        },
+        "concat-stream": {
+          "version": "1.5.1",
+          "from": "concat-stream@1.5.1",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz"
+        },
+        "core-util-is": {
+          "version": "1.0.1",
+          "from": "core-util-is@1.0.1",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.3",
+          "from": "escape-string-regexp@1.0.3",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "from": "generate-function@2.0.0",
+          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "from": "generate-object-property@1.2.0",
+          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+        },
+        "glob": {
+          "version": "5.0.15",
+          "from": "glob@>=5.0.3 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "from": "has-ansi@2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+        },
+        "inflight": {
+          "version": "1.0.4",
+          "from": "inflight@1.0.4",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "from": "inherits@2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        },
+        "is-my-json-valid": {
+          "version": "2.12.2",
+          "from": "is-my-json-valid@2.12.2",
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz"
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "from": "is-property@1.0.2",
+          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "jsonpointer": {
+          "version": "2.0.0",
+          "from": "jsonpointer@2.0.0",
+          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "minimatch@2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        },
+        "once": {
+          "version": "1.3.2",
+          "from": "once@1.3.2",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+        },
+        "pinkie": {
+          "version": "1.0.0",
+          "from": "pinkie@1.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+        },
+        "pinkie-promise": {
+          "version": "1.0.0",
+          "from": "pinkie-promise@1.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz"
+        },
+        "process-nextick-args": {
+          "version": "1.0.3",
+          "from": "process-nextick-args@1.0.3",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+        },
+        "readable-stream": {
+          "version": "2.0.4",
+          "from": "readable-stream@2.0.4",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz"
+        },
+        "rimraf": {
+          "version": "2.4.3",
+          "from": "rimraf@2.4.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "string_decoder@0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        },
+        "strip-ansi": {
+          "version": "3.0.0",
+          "from": "strip-ansi@3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "from": "typedarray@0.0.6",
+          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "from": "util-deprecate@1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+        },
+        "wrappy": {
+          "version": "1.0.1",
+          "from": "wrappy@1.0.1",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "from": "xtend@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "hapi": {
       "version": "7.5.3",
-      "from": "https://registry.npmjs.org/hapi/-/hapi-7.5.3.tgz",
+      "from": "hapi@7.5.3",
       "resolved": "https://registry.npmjs.org/hapi/-/hapi-7.5.3.tgz",
       "dependencies": {
         "accept": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz",
+          "from": "accept@1.0.0",
           "resolved": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz"
         },
         "boom": {
           "version": "2.5.1",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.5.1.tgz",
+          "from": "boom@2.5.1",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.5.1.tgz"
         },
         "call": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/call/-/call-1.0.0.tgz",
+          "from": "call@1.0.0",
           "resolved": "https://registry.npmjs.org/call/-/call-1.0.0.tgz"
         },
         "catbox": {
           "version": "4.1.0",
-          "from": "https://registry.npmjs.org/catbox/-/catbox-4.1.0.tgz",
+          "from": "catbox@4.1.0",
           "resolved": "https://registry.npmjs.org/catbox/-/catbox-4.1.0.tgz"
         },
         "catbox-memory": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.0.tgz",
+          "from": "catbox-memory@1.1.0",
           "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.0.tgz"
         },
         "cryptiles": {
           "version": "2.0.4",
-          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+          "from": "cryptiles@2.0.4",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "h2o2": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/h2o2/-/h2o2-2.0.1.tgz",
+          "from": "h2o2@2.0.1",
           "resolved": "https://registry.npmjs.org/h2o2/-/h2o2-2.0.1.tgz"
         },
         "heavy": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/heavy/-/heavy-1.0.0.tgz",
+          "from": "heavy@1.0.0",
           "resolved": "https://registry.npmjs.org/heavy/-/heavy-1.0.0.tgz"
         },
         "hoek": {
           "version": "2.9.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz",
+          "from": "hoek@2.9.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz"
         },
         "glue": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/glue/-/glue-1.0.0.tgz",
+          "from": "glue@1.0.0",
           "resolved": "https://registry.npmjs.org/glue/-/glue-1.0.0.tgz"
         },
         "inert": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/inert/-/inert-1.1.1.tgz",
+          "from": "inert@1.1.1",
           "resolved": "https://registry.npmjs.org/inert/-/inert-1.1.1.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "from": "lru-cache@2.5.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             }
           }
         },
         "iron": {
           "version": "2.1.2",
-          "from": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz",
+          "from": "iron@2.1.2",
           "resolved": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz"
         },
         "items": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/items/-/items-1.1.0.tgz",
+          "from": "items@1.1.0",
           "resolved": "https://registry.npmjs.org/items/-/items-1.1.0.tgz"
         },
         "joi": {
           "version": "4.7.0",
-          "from": "https://registry.npmjs.org/joi/-/joi-4.7.0.tgz",
+          "from": "joi@4.7.0",
           "resolved": "https://registry.npmjs.org/joi/-/joi-4.7.0.tgz",
           "dependencies": {
             "isemail": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+              "from": "isemail@1.1.1",
               "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
             }
           }
         },
         "kilt": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz",
+          "from": "kilt@1.1.1",
           "resolved": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz"
         },
         "mimos": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/mimos/-/mimos-1.0.1.tgz",
+          "from": "mimos@1.0.1",
           "resolved": "https://registry.npmjs.org/mimos/-/mimos-1.0.1.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.1.2.tgz",
+              "from": "mime-db@1.1.2",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.1.2.tgz"
             }
           }
         },
         "qs": {
           "version": "2.3.2",
-          "from": "https://registry.npmjs.org/qs/-/qs-2.3.2.tgz",
+          "from": "qs@2.3.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.2.tgz"
         },
         "rejoice": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/rejoice/-/rejoice-1.0.0.tgz",
+          "from": "rejoice@1.0.0",
           "resolved": "https://registry.npmjs.org/rejoice/-/rejoice-1.0.0.tgz",
           "dependencies": {
             "bossy": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/bossy/-/bossy-1.0.2.tgz",
+              "from": "bossy@1.0.2",
               "resolved": "https://registry.npmjs.org/bossy/-/bossy-1.0.2.tgz"
             }
           }
         },
         "shot": {
           "version": "1.3.5",
-          "from": "https://registry.npmjs.org/shot/-/shot-1.3.5.tgz",
+          "from": "shot@1.3.5",
           "resolved": "https://registry.npmjs.org/shot/-/shot-1.3.5.tgz"
         },
         "statehood": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/statehood/-/statehood-1.2.0.tgz",
+          "from": "statehood@1.2.0",
           "resolved": "https://registry.npmjs.org/statehood/-/statehood-1.2.0.tgz"
         },
         "subtext": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
+          "from": "subtext@1.0.2",
           "resolved": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
           "dependencies": {
             "content": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/content/-/content-1.0.1.tgz",
+              "from": "content@1.0.1",
               "resolved": "https://registry.npmjs.org/content/-/content-1.0.1.tgz"
             },
             "pez": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
+              "from": "pez@1.0.0",
               "resolved": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
               "dependencies": {
                 "b64": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz",
+                  "from": "b64@2.0.0",
                   "resolved": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz"
                 },
                 "nigel": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
+                  "from": "nigel@1.0.1",
                   "resolved": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
                   "dependencies": {
                     "vise": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz",
+                      "from": "vise@1.0.0",
                       "resolved": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz"
                     }
                   }
@@ -2933,115 +4281,115 @@
         },
         "topo": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz",
+          "from": "topo@1.0.2",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "vision": {
           "version": "1.2.1",
-          "from": "https://registry.npmjs.org/vision/-/vision-1.2.1.tgz",
+          "from": "vision@1.2.1",
           "resolved": "https://registry.npmjs.org/vision/-/vision-1.2.1.tgz"
         },
         "wreck": {
           "version": "5.0.1",
-          "from": "https://registry.npmjs.org/wreck/-/wreck-5.0.1.tgz",
+          "from": "wreck@5.0.1",
           "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.0.1.tgz"
         }
       }
     },
     "insist": {
       "version": "0.2.3",
-      "from": "https://registry.npmjs.org/insist/-/insist-0.2.3.tgz",
+      "from": "insist@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/insist/-/insist-0.2.3.tgz",
       "dependencies": {
         "esprima": {
           "version": "1.0.4",
-          "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "from": "esprima@>=1.0.4 <1.1.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
         },
         "stack-trace": {
           "version": "0.0.9",
-          "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+          "from": "stack-trace@>=0.0.7 <0.1.0",
           "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
         }
       }
     },
     "joi": {
       "version": "4.9.0",
-      "from": "https://registry.npmjs.org/joi/-/joi-4.9.0.tgz",
+      "from": "joi@>=4.7.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-4.9.0.tgz",
       "dependencies": {
         "hoek": {
           "version": "2.16.3",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "from": "hoek@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
         "topo": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+          "from": "topo@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
         },
         "isemail": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+          "from": "isemail@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
         },
         "moment": {
-          "version": "2.10.6",
-          "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
+          "version": "2.11.2",
+          "from": "moment@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
         }
       }
     },
     "load-grunt-tasks": {
-      "version": "3.3.0",
-      "from": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.3.0.tgz",
+      "version": "3.4.0",
+      "from": "load-grunt-tasks@>=3.1.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.4.0.tgz",
       "dependencies": {
         "arrify": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+          "version": "1.0.1",
+          "from": "arrify@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
         },
         "multimatch": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
+          "version": "2.1.0",
+          "from": "multimatch@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+              "from": "array-differ@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
             },
             "array-union": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+              "from": "array-union@1.0.1",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+                  "from": "array-uniq@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
                 }
               }
             },
             "minimatch": {
-              "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "version": "3.0.0",
+              "from": "minimatch@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                  "version": "1.1.3",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                      "version": "0.3.0",
+                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -3052,272 +4400,284 @@
         },
         "pkg-up": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
+          "from": "pkg-up@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
           "dependencies": {
             "find-up": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
+              "version": "1.1.0",
+              "from": "find-up@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
               "dependencies": {
                 "path-exists": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz"
+                  "version": "2.1.0",
+                  "from": "path-exists@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                 },
                 "pinkie-promise": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                  "version": "2.0.0",
+                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                   "dependencies": {
                     "pinkie": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                      "version": "2.0.4",
+                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
                 }
               }
+            }
+          }
+        },
+        "resolve-pkg": {
+          "version": "0.1.0",
+          "from": "resolve-pkg@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-0.1.0.tgz",
+          "dependencies": {
+            "resolve-from": {
+              "version": "2.0.0",
+              "from": "resolve-from@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
             }
           }
         }
       }
     },
     "mocha": {
-      "version": "2.3.3",
-      "from": "https://registry.npmjs.org/mocha/-/mocha-2.3.3.tgz",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.3.3.tgz",
+      "version": "2.4.5",
+      "from": "mocha@>=1.20.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
       "dependencies": {
         "commander": {
           "version": "2.3.0",
-          "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "from": "commander@2.3.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
         },
         "debug": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+          "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
-              "version": "0.6.2",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "diff": {
           "version": "1.4.0",
-          "from": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+          "from": "diff@1.4.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "from": "escape-string-regexp@1.0.2",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
         },
         "glob": {
           "version": "3.2.3",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "from": "glob@3.2.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "from": "minimatch@>=0.2.11 <0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.7.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                  "version": "2.7.3",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "growl": {
           "version": "1.8.1",
-          "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+          "from": "growl@1.8.1",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
         },
         "jade": {
           "version": "0.26.3",
-          "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "from": "jade@0.26.3",
           "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
           "dependencies": {
             "commander": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+              "from": "commander@0.6.1",
               "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
             },
             "mkdirp": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+              "from": "mkdirp@0.3.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
         "mkdirp": {
-          "version": "0.5.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "version": "0.5.1",
+          "from": "mkdirp@0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "supports-color": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+          "from": "supports-color@1.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
         }
       }
     },
     "mocha-text-cov": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/mocha-text-cov/-/mocha-text-cov-0.1.0.tgz",
+      "from": "mocha-text-cov@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/mocha-text-cov/-/mocha-text-cov-0.1.0.tgz"
     },
     "mozlog": {
-      "version": "2.0.2",
-      "from": "mozlog@2.0.2",
-      "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.2.tgz",
+      "version": "2.0.3",
+      "from": "mozlog@>=2.0.3 <3.0.0",
+      "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.3.tgz",
       "dependencies": {
         "intel": {
-          "version": "1.0.2",
-          "from": "intel@1.0.2",
-          "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.2.tgz",
+          "version": "1.1.0",
+          "from": "intel@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/intel/-/intel-1.1.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+              "from": "chalk@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                  "from": "ansi-styles@>=2.1.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                  "version": "1.0.4",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "dbug": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz",
+              "from": "dbug@>=0.4.2 <0.5.0",
               "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+              "from": "stack-trace@>=0.0.9 <0.1.0",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             },
             "strftime": {
               "version": "0.9.2",
-              "from": "https://registry.npmjs.org/strftime/-/strftime-0.9.2.tgz",
+              "from": "strftime@>=0.9.2 <0.10.0",
               "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.9.2.tgz"
             },
             "symbol": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz",
+              "from": "symbol@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
             },
             "utcstring": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz",
+              "from": "utcstring@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
             }
           }
         },
         "merge": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+          "from": "merge@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
         }
       }
     },
     "mysql": {
-      "version": "2.9.0",
-      "from": "https://registry.npmjs.org/mysql/-/mysql-2.9.0.tgz",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.9.0.tgz",
+      "version": "2.10.2",
+      "from": "mysql@>=2.5.5 <3.0.0",
+      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.10.2.tgz",
       "dependencies": {
         "bignumber.js": {
-          "version": "2.0.7",
-          "from": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.0.7.tgz",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.0.7.tgz"
+          "version": "2.1.4",
+          "from": "bignumber.js@2.1.4",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.1.4.tgz"
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "from": "readable-stream@>=1.1.13 <1.2.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+              "version": "1.0.2",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "from": "isarray@0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
@@ -3326,59 +4686,59 @@
     },
     "mysql-patcher": {
       "version": "0.7.0",
-      "from": "https://registry.npmjs.org/mysql-patcher/-/mysql-patcher-0.7.0.tgz",
+      "from": "mysql-patcher@>=0.7.0 <0.8.0",
       "resolved": "https://registry.npmjs.org/mysql-patcher/-/mysql-patcher-0.7.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "clone": {
           "version": "0.1.19",
-          "from": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz",
+          "from": "clone@>=0.1.18 <0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
         },
         "glob": {
           "version": "5.0.15",
-          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "from": "glob@>=5.0.3 <6.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "from": "inflight@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@1.0.1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                  "version": "1.1.3",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                      "version": "0.3.0",
+                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -3386,54 +4746,54 @@
               }
             },
             "once": {
-              "version": "1.3.2",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "version": "1.3.3",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
         },
         "xtend": {
-          "version": "4.0.0",
-          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+          "version": "4.0.1",
+          "from": "xtend@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "nock": {
       "version": "1.9.0",
-      "from": "https://registry.npmjs.org/nock/-/nock-1.9.0.tgz",
+      "from": "nock@>=1.2.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/nock/-/nock-1.9.0.tgz",
       "dependencies": {
         "chai": {
           "version": "1.10.0",
-          "from": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
+          "from": "chai@>=1.9.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
           "dependencies": {
             "assertion-error": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+              "from": "assertion-error@1.0.0",
               "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
             },
             "deep-eql": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+              "from": "deep-eql@0.1.3",
               "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
               "dependencies": {
                 "type-detect": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+                  "from": "type-detect@0.1.1",
                   "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
                 }
               }
@@ -3442,36 +4802,36 @@
         },
         "debug": {
           "version": "1.0.4",
-          "from": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+          "from": "debug@>=1.0.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "from": "ms@0.6.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+          "from": "lodash@2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "propagate": {
           "version": "0.3.1",
-          "from": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz",
+          "from": "propagate@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
         }
       }
@@ -3494,89 +4854,106 @@
       }
     },
     "proxyquire": {
-      "version": "1.7.3",
-      "from": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.7.3.tgz",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.7.3.tgz",
+      "version": "1.7.4",
+      "from": "proxyquire@>=1.6.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.7.4.tgz",
       "dependencies": {
         "fill-keys": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+          "from": "fill-keys@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
           "dependencies": {
             "is-object": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+              "from": "is-object@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz"
             },
             "merge-descriptors": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz"
+              "version": "1.0.1",
+              "from": "merge-descriptors@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
             }
           }
         },
         "module-not-found-error": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+          "from": "module-not-found-error@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz"
         }
       }
     },
     "read": {
       "version": "1.0.7",
-      "from": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "from": "read@>=1.0.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "dependencies": {
         "mute-stream": {
-          "version": "0.0.5",
-          "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+          "version": "0.0.6",
+          "from": "mute-stream@>=0.0.4 <0.1.0",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
         }
       }
     },
     "request": {
-      "version": "2.65.0",
-      "from": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
+      "version": "2.69.0",
+      "from": "request@>=2.54.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
       "dependencies": {
+        "aws-sign2": {
+          "version": "0.6.0",
+          "from": "aws-sign2@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+        },
+        "aws4": {
+          "version": "1.2.1",
+          "from": "aws4@>=1.2.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.7.3",
+              "from": "lru-cache@>=2.6.5 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+            }
+          }
+        },
         "bl": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+          "version": "1.0.3",
+          "from": "bl@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
           "dependencies": {
             "readable-stream": {
-              "version": "2.0.4",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+              "version": "2.0.5",
+              "from": "readable-stream@>=2.0.5 <2.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                  "version": "1.0.6",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -3585,658 +4962,456 @@
         },
         "caseless": {
           "version": "0.11.0",
-          "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "from": "caseless@>=0.11.0 <0.12.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-        },
-        "extend": {
-          "version": "3.0.0",
-          "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-        },
-        "form-data": {
-          "version": "1.0.0-rc3",
-          "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-          "dependencies": {
-            "async": {
-              "version": "1.5.0",
-              "from": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-            }
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-        },
-        "mime-types": {
-          "version": "2.1.7",
-          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-          "dependencies": {
-            "mime-db": {
-              "version": "1.19.0",
-              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
-            }
-          }
-        },
-        "node-uuid": {
-          "version": "1.4.3",
-          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-        },
-        "qs": {
-          "version": "5.2.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-        },
-        "tunnel-agent": {
-          "version": "0.4.1",
-          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-        },
-        "tough-cookie": {
-          "version": "2.2.0",
-          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
-        },
-        "http-signature": {
-          "version": "0.11.0",
-          "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-          "dependencies": {
-            "assert-plus": {
-              "version": "0.1.5",
-              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-            },
-            "asn1": {
-              "version": "0.1.11",
-              "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-            },
-            "ctype": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-            }
-          }
-        },
-        "oauth-sign": {
-          "version": "0.8.0",
-          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-        },
-        "hawk": {
-          "version": "3.1.1",
-          "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.1.tgz",
-          "dependencies": {
-            "hoek": {
-              "version": "2.16.3",
-              "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-            },
-            "boom": {
-              "version": "2.10.1",
-              "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-            }
-          }
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "from": "combined-stream@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+              "from": "delayed-stream@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
             }
           }
         },
-        "isstream": {
-          "version": "0.1.2",
-          "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+        "extend": {
+          "version": "3.0.0",
+          "from": "extend@>=3.0.0 <3.1.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "from": "forever-agent@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+        },
+        "form-data": {
+          "version": "1.0.0-rc3",
+          "from": "form-data@>=1.0.0-rc3 <1.1.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "from": "async@>=1.4.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+            }
+          }
         },
         "har-validator": {
-          "version": "2.0.2",
-          "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz",
+          "version": "2.0.6",
+          "from": "har-validator@>=2.0.6 <2.1.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+              "from": "chalk@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                  "from": "ansi-styles@>=2.1.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                  "version": "1.0.4",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.9.0",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "from": "commander@>=2.9.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                  "from": "graceful-readlink@>=1.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "is-my-json-valid": {
-              "version": "2.12.3",
-              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
+              "version": "2.12.4",
+              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                  "from": "generate-function@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                  "from": "generate-object-property@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                      "from": "is-property@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                  "from": "jsonpointer@2.0.0",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "from": "xtend@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "pinkie-promise": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+              "version": "2.0.0",
+              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
               "dependencies": {
                 "pinkie": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                  "version": "2.0.4",
+                  "from": "pinkie@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                 }
               }
             }
           }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "from": "hawk@>=3.1.0 <3.2.0",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "dependencies": {
+            "hoek": {
+              "version": "2.16.3",
+              "from": "hoek@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+            },
+            "boom": {
+              "version": "2.10.1",
+              "from": "boom@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+            },
+            "cryptiles": {
+              "version": "2.0.5",
+              "from": "cryptiles@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+            },
+            "sntp": {
+              "version": "1.0.9",
+              "from": "sntp@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+            }
+          }
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "from": "http-signature@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.2.0",
+              "from": "assert-plus@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+            },
+            "jsprim": {
+              "version": "1.2.2",
+              "from": "jsprim@>=1.2.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+              "dependencies": {
+                "extsprintf": {
+                  "version": "1.0.2",
+                  "from": "extsprintf@1.0.2",
+                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                },
+                "json-schema": {
+                  "version": "0.2.2",
+                  "from": "json-schema@0.2.2",
+                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                },
+                "verror": {
+                  "version": "1.3.6",
+                  "from": "verror@1.3.6",
+                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                }
+              }
+            },
+            "sshpk": {
+              "version": "1.7.4",
+              "from": "sshpk@>=1.7.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.2.3",
+                  "from": "asn1@>=0.2.3 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                },
+                "dashdash": {
+                  "version": "1.13.0",
+                  "from": "dashdash@>=1.10.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    }
+                  }
+                },
+                "jsbn": {
+                  "version": "0.1.0",
+                  "from": "jsbn@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                },
+                "tweetnacl": {
+                  "version": "0.13.3",
+                  "from": "tweetnacl@>=0.13.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                },
+                "jodid25519": {
+                  "version": "1.0.2",
+                  "from": "jodid25519@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "from": "is-typedarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "from": "isstream@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.9",
+          "from": "mime-types@>=2.1.7 <2.2.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
+          "dependencies": {
+            "mime-db": {
+              "version": "1.21.0",
+              "from": "mime-db@>=1.21.0 <1.22.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+            }
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.7",
+          "from": "node-uuid@>=1.4.7 <1.5.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+        },
+        "oauth-sign": {
+          "version": "0.8.1",
+          "from": "oauth-sign@>=0.8.0 <0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
+        },
+        "qs": {
+          "version": "6.0.2",
+          "from": "qs@>=6.0.2 <6.1.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "from": "stringstream@>=0.0.4 <0.1.0",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+        },
+        "tough-cookie": {
+          "version": "2.2.1",
+          "from": "tough-cookie@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+        },
+        "tunnel-agent": {
+          "version": "0.4.2",
+          "from": "tunnel-agent@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
         }
       }
     },
     "sinon": {
-      "version": "1.17.1",
-      "from": "https://registry.npmjs.org/sinon/-/sinon-1.17.1.tgz",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.1.tgz",
+      "version": "1.17.3",
+      "from": "sinon@>=1.15.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.3.tgz",
       "dependencies": {
         "formatio": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+          "from": "formatio@1.1.1",
           "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
         },
         "util": {
           "version": "0.10.3",
-          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "from": "util@>=0.10.3 <1.0.0",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "lolex": {
           "version": "1.3.2",
-          "from": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+          "from": "lolex@1.3.2",
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz"
         },
         "samsam": {
           "version": "1.1.2",
-          "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+          "from": "samsam@1.1.2",
           "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
         }
       }
     },
     "time-grunt": {
-      "version": "1.2.1",
-      "from": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.2.1.tgz",
+      "version": "1.3.0",
+      "from": "time-grunt@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.3.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "version": "1.0.4",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "from": "has-ansi@2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "from": "strip-ansi@3.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "date-time": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz",
+          "from": "date-time@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz"
         },
         "figures": {
           "version": "1.4.0",
-          "from": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz",
+          "from": "figures@1.4.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "number-is-nan": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+          "from": "number-is-nan@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
         },
         "pretty-ms": {
-          "version": "1.4.0",
-          "from": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-1.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-1.4.0.tgz",
+          "version": "2.1.0",
+          "from": "pretty-ms@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
           "dependencies": {
-            "get-stdin": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-            },
             "is-finite": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+              "from": "is-finite@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
-            },
-            "meow": {
-              "version": "3.4.2",
-              "from": "https://registry.npmjs.org/meow/-/meow-3.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-3.4.2.tgz",
-              "dependencies": {
-                "camelcase-keys": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                    },
-                    "map-obj": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                    }
-                  }
-                },
-                "loud-rejection": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz"
-                },
-                "minimist": {
-                  "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                },
-                "normalize-package-data": {
-                  "version": "2.3.4",
-                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.4.tgz",
-                  "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.4.tgz",
-                  "dependencies": {
-                    "hosted-git-info": {
-                      "version": "2.1.4",
-                      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
-                    },
-                    "is-builtin-module": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                      "dependencies": {
-                        "builtin-modules": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
-                        }
-                      }
-                    },
-                    "semver": {
-                      "version": "5.0.3",
-                      "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
-                    },
-                    "validate-npm-package-license": {
-                      "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                      "dependencies": {
-                        "spdx-correct": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.1.tgz",
-                          "dependencies": {
-                            "spdx-license-ids": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz"
-                            }
-                          }
-                        },
-                        "spdx-expression-parse": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
-                          "dependencies": {
-                            "spdx-exceptions": {
-                              "version": "1.0.3",
-                              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz"
-                            },
-                            "spdx-license-ids": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-                },
-                "read-pkg-up": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                  "dependencies": {
-                    "find-up": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
-                      "dependencies": {
-                        "path-exists": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz"
-                        },
-                        "pinkie-promise": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "read-pkg": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                      "dependencies": {
-                        "load-json-file": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.2",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                            },
-                            "parse-json": {
-                              "version": "2.2.0",
-                              "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                              "dependencies": {
-                                "error-ex": {
-                                  "version": "1.2.0",
-                                  "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.2.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.2.0.tgz"
-                                }
-                              }
-                            },
-                            "pify": {
-                              "version": "2.2.0",
-                              "from": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz"
-                            },
-                            "pinkie-promise": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-bom": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                              "dependencies": {
-                                "is-utf8": {
-                                  "version": "0.2.0",
-                                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "path-type": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.2",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                            },
-                            "pify": {
-                              "version": "2.2.0",
-                              "from": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz"
-                            },
-                            "pinkie-promise": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "redent": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                  "dependencies": {
-                    "indent-string": {
-                      "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                      "dependencies": {
-                        "repeating": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "strip-indent": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-                    }
-                  }
-                },
-                "trim-newlines": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-                }
-              }
             },
             "parse-ms": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.0.tgz",
+              "from": "parse-ms@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.0.tgz"
             },
             "plur": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
+              "from": "plur@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "from": "text-table@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
     "urijs": {
-      "version": "1.16.1",
-      "from": "https://registry.npmjs.org/urijs/-/urijs-1.16.1.tgz",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.16.1.tgz"
+      "version": "1.17.0",
+      "from": "urijs@>=1.16.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.17.0.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "fxa-notifier-aws": "1.0.0",
     "hapi": "7.5.3",
     "joi": "^4.7.0",
-    "mozlog": "^2.0.2",
+    "mozlog": "^2.0.3",
     "mysql": "^2.5.5",
     "mysql-patcher": "^0.7.0",
     "request": "^2.54.0",


### PR DESCRIPTION
Picks up this fix for exception logging - mozilla/mozlog@e11def1

r? - @seanmonstar 