### PR TITLE
tuneups for bin/purge_expired_tokens.js

### DIFF
--- a/bin/purge_expired_tokens.js
+++ b/bin/purge_expired_tokens.js
@@ -47,7 +47,7 @@ if (!program.pocketId) {
 }
 
 const numberOfTokens = parseInt(program.tokenCount) || 200;
-const delaySeconds = parseInt(program.delaySeconds) || 1; // Default 1 seconds
+const delaySeconds = Number(program.delaySeconds) || 1; // Default 1 seconds
 const ignorePocketClientId = program.pocketId;
 
 db.ping().done(function() {

--- a/bin/purge_expired_tokens.js
+++ b/bin/purge_expired_tokens.js
@@ -15,8 +15,12 @@
  *
  * */
 
+const config = require('../lib/config');
+const package = require('../package.json');
 const program = require('commander');
-const package = require('./../package.json');
+
+// Don't bother updating the clients table.
+config.set('db.autoUpdateClients', false);
 
 program
   .version(package.version)

--- a/lib/db/mysql/index.js
+++ b/lib/db/mysql/index.js
@@ -514,15 +514,17 @@ MysqlStore.prototype = {
 
   purgeExpiredTokens: function purgeExpiredTokens(numberOfTokens, delaySeconds, ignoreClientId){
     var self = this;
+    if (! ignoreClientId) {
+      throw new Error('empty ignoreClientId');
+    }
 
-    return self.getClientDevelopers(ignoreClientId)
+    return self.getClient(ignoreClientId)
       .then(function (ignoreClient) {
-        // This ensures that purgeExpiredTokens can not be called with an invalid ignoreClientId
-      })
-      .catch(function(err){
-        err = new Error('Invalid ignoreClientId, please ensure client exists.');
-        logger.error(err);
-        throw err;
+        // This ensures that purgeExpiredTokens can not be called with an
+        // unknown ignoreClientId.
+        if (! ignoreClient) {
+          throw new Error('unknown ignoreClientId ' + ignoreClientId);
+        }
       })
       .then(function () {
         var deleteBatchSize = 200;

--- a/lib/db/mysql/index.js
+++ b/lib/db/mysql/index.js
@@ -560,7 +560,7 @@ MysqlStore.prototype = {
 
               deletedItems = deletedItems + res.affectedRows;
 
-              return P.delay(delaySeconds)
+              return P.delay(delaySeconds * 1000)
                 .then(function () {
                   return promiseWhile();
                 });

--- a/test/db/index.js
+++ b/test/db/index.js
@@ -170,10 +170,21 @@ describe('db', function() {
       it('should fail purgeExpiredTokens without ignoreClientId', function() {
         return db.purgeExpiredTokens(1000, 5)
           .then( function () {
-            assert.fail('Purge token should fail with no ignoreClientId');
+            assert.fail('purgeExpiredTokens() should fail with an empty ignoreClientId');
           })
           .catch( function (error) {
-            assert.equal(error.message, 'Invalid ignoreClientId, please ensure client exists.');
+            assert.equal(error.message, 'empty ignoreClientId');
+          });
+      });
+
+      it('should fail purgeExpiredTokens with an unknown ignoreClientId', function() {
+        var unknownClientId = 'deadbeefdeadbeef';
+        return db.purgeExpiredTokens(1000, 5, unknownClientId)
+          .then( function () {
+            assert.fail('purgeExpiredTokens() should fail with an unknown ignoreClientId');
+          })
+          .catch( function (error) {
+            assert.equal(error.message, 'unknown ignoreClientId ' + unknownClientId);
           });
       });
 


### PR DESCRIPTION
This tunes up bin/purge_expired_tokens.js:

1) log uncaughtException; minimum log level of info
   - moves to more conventional logging in this repo and nothing below log level info
   - prints out any uncaughtException

2) use db.getClient() to check for unknown clientId
   - the `clients` table is the one that matters

3) set db.autoUpdateClients config to false
   - No point in doing this in dev for the purposes of this script, and disabled in prod/stage.

4) moar logging
   - because https://youtu.be/-fQGPZTECYs?t=24

5) Promise.delay takes milliseconds; also allow subsecond delay for command line option
   - nuff said

r? - @vbudhram 

Maybe look at each commit separately, instead of the aggregate.