### PR TITLE
fix(travis): test on node4/node6 with default npm & g++-4.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
-  - '0.10'
   - '4'
+  - '6'
 
 dist: trusty
 sudo: true
@@ -28,16 +28,11 @@ notifications:
     skip_join: false
 
 env:
-  - NODE_ENV=test DB=memory
-  - NODE_ENV=test DB=mysql
+  - CXX=g++-4.8 NODE_ENV=test DB=memory
+  - CXX=g++-4.8 NODE_ENV=test DB=mysql
 
 before_install:
-  - npm install -g npm@2
   - npm config set spin false
-
-install:
-  # use c++-11 with node4, default compiler on downlevel versions
-  - if [ $TRAVIS_NODE_VERSION == "4" ]; then CXX=g++-4.8 npm install; else npm install; fi
 
 before_script:
   - "mysql -u root -NBe 'select version()'"


### PR DESCRIPTION
Changes to travis:
- drop 0.10, add 6
- always g++-4.8
- use the default npm that comes with node (4 => 2, 6 => 3)
- npm install automagically happens for node projects; extra logic no longer needed.

r? - @seanmonstar 