### PR TITLE
Begin expiring access tokens beyond a configurable epoch.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -101,11 +101,15 @@ const conf = convict({
     }
   },
   expiration: {
-    // in JavaScript, we live in milliseconds
     accessToken: {
       doc: 'Access Tokens maximum expiration (can live shorter)',
       format: 'duration',
       default: '2 weeks'
+    },
+    accessTokenExpiryEpoch: {
+      doc: 'Timestamp after which access token expiry is actively enforced',
+      format: 'timestamp',
+      default: '2017-01-01'
     },
     code: {
       doc: 'Clients must trade codes for tokens before they expire',

--- a/lib/token.js
+++ b/lib/token.js
@@ -4,6 +4,7 @@
 
 const AppError = require('./error');
 const auth = require('./auth');
+const config = require('./config');
 const db = require('./db');
 const encrypt = require('./encrypt');
 const Scope = require('./scope');
@@ -17,6 +18,18 @@ exports.verify = function verify(token) {
     if (!token) {
       throw AppError.invalidToken();
     } else if (+token.expiresAt < Date.now()) {
+      // We dug ourselves a bit of a hole with token expiry,
+      // and this logic is here to help us climb back out.
+      // There's a huge backlog of expired tokens in the wild,
+      // and if we start rejecting them all at once, then the
+      // thundering herd of token updates will crush our db.
+      // Instead we "grandfather" these old tokens in and
+      // pretend they're still valid, while chipping away at
+      // the backlog by either slowly reducing this epoch, or
+      // by slowly purging older tokens from the db.
+      if (+token.expiresAt >= config.get('expiration.accessTokenExpiryEpoch')) {
+        throw AppError.expiredToken(token.expiresAt);
+      }
       logger.warn('token.verify.expired', {
         user: token.userId.toString('hex'),
         client_id: token.clientId.toString('hex'),
@@ -24,7 +37,6 @@ exports.verify = function verify(token) {
         created_at: token.createdAt,
         expires_at: token.expiresAt
       });
-      //throw AppError.expiredToken(token.expiresAt);
     } else if ((+token.createdAt + TWENTY_FOUR_HOURS) < Date.now()) {
       // Log a warning if reliers are using access tokens that are more
       // than 24 hours old.  Eventually we will shorten the expiry time

--- a/test/api.js
+++ b/test/api.js
@@ -1883,8 +1883,10 @@ describe('/v1', function() {
       });
     });
 
-    it.skip('should reject expired tokens', function() {
+    it('should reject expired tokens from after the epoch', function() {
       this.slow(2200);
+      var epoch = config.get('expiration.accessTokenExpiryEpoch');
+      config.set('expiration.accessTokenExpiryEpoch', Date.now());
       return newToken({
         ttl: 1
       }).delay(1500).then(function(res) {
@@ -1899,6 +1901,30 @@ describe('/v1', function() {
       }).then(function(res) {
         assert.equal(res.statusCode, 400);
         assert.equal(res.result.errno, 115);
+      }).finally(function() {
+        config.set('expiration.accessTokenExpiryEpoch', epoch);
+      });
+    });
+
+    it('should accept expired tokens from before the epoch', function() {
+      this.slow(2200);
+      var epoch = config.get('expiration.accessTokenExpiryEpoch');
+      config.set('expiration.accessTokenExpiryEpoch', Date.now() + 2000);
+      return newToken({
+        ttl: 1
+      }).delay(1500).then(function(res) {
+        assert.equal(res.statusCode, 200);
+        assert.equal(res.result.expires_in, 1);
+        return Server.api.post({
+          url: '/verify',
+          payload: {
+            token: res.result.access_token
+          }
+        });
+      }).then(function(res) {
+        assert.equal(res.statusCode, 200);
+      }).finally(function() {
+        config.set('expiration.accessTokenExpiryEpoch', epoch);
       });
     });
 


### PR DESCRIPTION
This implements the approach suggested in https://bugzilla.mozilla.org/show_bug.cgi?id=1320216#c1 to start more strictly enforcing access token expiry.  It allows old tokens to remain in their current "dont expire unless physically deleted" state, while any newly-issued tokens will expire normally.

@seanmonstar r?

@jrgm let me know if you have any concerns about the impact of this approach on server load.  It seems like it should be OK as it leaves the outstanding backlog of unexpired tokens alone.