### PR TITLE
Enable security headers

### DIFF
--- a/lib/server/config.js
+++ b/lib/server/config.js
@@ -14,7 +14,7 @@ module.exports = {
           maxAge: 15552000,
           includeSubdomains: true
         },
-        xframe: false,
+        xframe: true,
         xss: true,
         noOpen: false,
         noSniff: true

--- a/lib/server/config.js
+++ b/lib/server/config.js
@@ -17,7 +17,7 @@ module.exports = {
         xframe: false,
         xss: false,
         noOpen: false,
-        noSniff: false
+        noSniff: true
       }
     }
   }

--- a/lib/server/config.js
+++ b/lib/server/config.js
@@ -15,7 +15,7 @@ module.exports = {
           includeSubdomains: true
         },
         xframe: false,
-        xss: false,
+        xss: true,
         noOpen: false,
         noSniff: true
       }

--- a/test/server.js
+++ b/test/server.js
@@ -31,10 +31,13 @@ function checkVersionAndHeaders(path) {
       var xssHeader = res.headers['x-xss-protection'];
       assert.equal(xssHeader, '1; mode=block');
 
+      // frame options header
+      var frameHeader = res.headers['x-frame-options'];
+      assert.equal(frameHeader, 'DENY');
+
       // but the other security builtin headers from hapi are not set
       var other = {
         'x-download-options': 1,
-        'x-frame-options': 1,
       };
 
       Object.keys(res.headers).forEach(function(header) {

--- a/test/server.js
+++ b/test/server.js
@@ -27,11 +27,14 @@ function checkVersionAndHeaders(path) {
       var contentTypeHeader = res.headers['x-content-type-options'];
       assert.equal(contentTypeHeader, 'nosniff');
 
+      // xss protection header
+      var xssHeader = res.headers['x-xss-protection'];
+      assert.equal(xssHeader, '1; mode=block');
+
       // but the other security builtin headers from hapi are not set
       var other = {
         'x-download-options': 1,
         'x-frame-options': 1,
-        'x-xss-protection': 1
       };
 
       Object.keys(res.headers).forEach(function(header) {

--- a/test/server.js
+++ b/test/server.js
@@ -23,9 +23,12 @@ function checkVersionAndHeaders(path) {
       var stsHeader = res.headers['strict-transport-security'];
       assert.equal(stsHeader, 'max-age=15552000; includeSubDomains');
 
+      // content type options header
+      var contentTypeHeader = res.headers['x-content-type-options'];
+      assert.equal(contentTypeHeader, 'nosniff');
+
       // but the other security builtin headers from hapi are not set
       var other = {
-        'x-content-type-options': 1,
         'x-download-options': 1,
         'x-frame-options': 1,
         'x-xss-protection': 1


### PR DESCRIPTION
Add security headers (see also the commit messages).

I'm assuming these API endpoints aren't iframed anywhere.

We discussed having the webserver send these, but having this in code allows it to be tested and makes dev and prod environments more similar. Both of those things make @jrgm happy.