### PR TITLE
fix(scripts): Use pure JS module to generate RSA keypairs

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -213,6 +213,7 @@
     "fxa-shared": {
       "version": "1.0.4",
       "from": "fxa-shared@1.0.4",
+      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.4.tgz",
       "dependencies": {
         "accept-language": {
           "version": "2.0.17",
@@ -230,18 +231,6 @@
           "version": "2.14.1",
           "from": "moment@2.14.1",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz"
-        }
-      }
-    },
-    "generate-rsa-keypair": {
-      "version": "0.1.1",
-      "from": "generate-rsa-keypair@0.1.1",
-      "resolved": "https://registry.npmjs.org/generate-rsa-keypair/-/generate-rsa-keypair-0.1.1.tgz",
-      "dependencies": {
-        "nan": {
-          "version": "2.4.0",
-          "from": "nan@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
         }
       }
     },
@@ -305,9 +294,9 @@
                       }
                     },
                     "signal-exit": {
-                      "version": "3.0.1",
+                      "version": "3.0.2",
                       "from": "signal-exit@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
                     }
                   }
                 },
@@ -681,7 +670,7 @@
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
-                  "from": "chalk@>=1.1.1 <1.2.0",
+                  "from": "chalk@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                   "dependencies": {
                     "ansi-styles": {
@@ -942,9 +931,9 @@
                           }
                         },
                         "signal-exit": {
-                          "version": "3.0.1",
+                          "version": "3.0.2",
                           "from": "signal-exit@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
                         }
                       }
                     },
@@ -1325,25 +1314,30 @@
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.24.1.tgz",
           "dependencies": {
             "concat-stream": {
-              "version": "1.5.2",
+              "version": "1.6.0",
               "from": "concat-stream@>=1.4.6 <2.0.0",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@>=2.0.3 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "from": "typedarray@>=0.0.6 <0.0.7",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
-                  "version": "2.0.6",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "version": "2.2.2",
+                  "from": "readable-stream@>=2.2.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
                   "dependencies": {
+                    "buffer-shims": {
+                      "version": "1.0.0",
+                      "from": "buffer-shims@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                    },
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "core-util-is@>=1.0.0 <1.1.0",
@@ -1374,9 +1368,9 @@
               }
             },
             "debug": {
-              "version": "2.3.3",
+              "version": "2.6.0",
               "from": "debug@>=2.1.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.2",
@@ -1599,9 +1593,9 @@
                   }
                 },
                 "jsonpointer": {
-                  "version": "4.0.0",
+                  "version": "4.0.1",
                   "from": "jsonpointer@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
@@ -1820,9 +1814,9 @@
               "resolved": "https://registry.npmjs.org/cst/-/cst-0.4.9.tgz",
               "dependencies": {
                 "babel-runtime": {
-                  "version": "6.18.0",
+                  "version": "6.20.0",
                   "from": "babel-runtime@>=6.9.2 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
                   "dependencies": {
                     "core-js": {
                       "version": "2.4.1",
@@ -1830,21 +1824,21 @@
                       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                     },
                     "regenerator-runtime": {
-                      "version": "0.9.6",
-                      "from": "regenerator-runtime@>=0.9.5 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz"
+                      "version": "0.10.1",
+                      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz"
                     }
                   }
                 },
                 "babylon": {
-                  "version": "6.14.1",
+                  "version": "6.15.0",
                   "from": "babylon@>=6.8.1 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
                 },
                 "source-map-support": {
-                  "version": "0.4.6",
+                  "version": "0.4.8",
                   "from": "source-map-support@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.6.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.8.tgz",
                   "dependencies": {
                     "source-map": {
                       "version": "0.5.6",
@@ -2316,9 +2310,9 @@
               "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.1.tgz"
             },
             "resolve": {
-              "version": "1.1.7",
+              "version": "1.2.0",
               "from": "resolve@>=1.1.6 <2.0.0",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz"
             },
             "strip-bom": {
               "version": "2.0.0",
@@ -2586,9 +2580,9 @@
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         },
                         "kind-of": {
-                          "version": "3.0.4",
+                          "version": "3.1.0",
                           "from": "kind-of@>=3.0.2 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
                           "dependencies": {
                             "is-buffer": {
                               "version": "1.1.4",
@@ -2685,9 +2679,9 @@
                   "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
                   "dependencies": {
                     "binary-extensions": {
-                      "version": "1.7.0",
+                      "version": "1.8.0",
                       "from": "binary-extensions@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.7.0.tgz"
+                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
                     }
                   }
                 },
@@ -2720,7 +2714,7 @@
                     },
                     "readable-stream": {
                       "version": "2.2.2",
-                      "from": "readable-stream@>=2.0.2 <3.0.0",
+                      "from": "readable-stream@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
                       "dependencies": {
                         "buffer-shims": {
@@ -2763,19 +2757,19 @@
                   }
                 },
                 "fsevents": {
-                  "version": "1.0.15",
+                  "version": "1.0.17",
                   "from": "fsevents@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.15.tgz",
+                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.17.tgz",
                   "dependencies": {
                     "nan": {
-                      "version": "2.4.0",
+                      "version": "2.5.0",
                       "from": "nan@>=2.3.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.0.tgz"
                     },
                     "node-pre-gyp": {
-                      "version": "0.6.29",
+                      "version": "0.6.32",
                       "from": "node-pre-gyp@>=0.6.29 <0.7.0",
-                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.29.tgz"
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz"
                     },
                     "abbrev": {
                       "version": "1.0.9",
@@ -2812,10 +2806,10 @@
                       "from": "assert-plus@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                     },
-                    "async": {
-                      "version": "1.5.2",
-                      "from": "async@>=1.5.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+                    "asynckit": {
+                      "version": "0.4.0",
+                      "from": "asynckit@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
                     },
                     "aws-sign2": {
                       "version": "0.6.0",
@@ -2823,9 +2817,14 @@
                       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                     },
                     "aws4": {
-                      "version": "1.4.1",
+                      "version": "1.5.0",
                       "from": "aws4@>=1.2.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
+                      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.0",
+                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
                     },
                     "balanced-match": {
                       "version": "0.4.2",
@@ -2837,35 +2836,30 @@
                       "from": "block-stream@*",
                       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
                     },
+                    "brace-expansion": {
+                      "version": "1.1.6",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+                    },
                     "boom": {
                       "version": "2.10.1",
                       "from": "boom@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                    },
-                    "brace-expansion": {
-                      "version": "1.1.5",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz"
-                    },
-                    "buffer-shims": {
-                      "version": "1.0.0",
-                      "from": "buffer-shims@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                     },
                     "caseless": {
                       "version": "0.11.0",
                       "from": "caseless@>=0.11.0 <0.12.0",
                       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                     },
-                    "chalk": {
-                      "version": "1.1.3",
-                      "from": "chalk@>=1.1.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+                    "buffer-shims": {
+                      "version": "1.0.0",
+                      "from": "buffer-shims@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                     },
                     "code-point-at": {
-                      "version": "1.0.0",
+                      "version": "1.1.0",
                       "from": "code-point-at@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
                     },
                     "combined-stream": {
                       "version": "1.0.5",
@@ -2943,9 +2937,9 @@
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                     },
                     "form-data": {
-                      "version": "1.0.0-rc4",
-                      "from": "form-data@>=1.0.0-rc4 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
+                      "version": "2.1.2",
+                      "from": "form-data@>=2.1.1 <2.2.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz"
                     },
                     "fs.realpath": {
                       "version": "1.0.0",
@@ -2963,9 +2957,9 @@
                       "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
                     },
                     "gauge": {
-                      "version": "2.6.0",
-                      "from": "gauge@>=2.6.0 <2.7.0",
-                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz"
+                      "version": "2.7.2",
+                      "from": "gauge@>=2.7.1 <2.8.0",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz"
                     },
                     "generate-function": {
                       "version": "2.0.0",
@@ -2978,14 +2972,14 @@
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
                     },
                     "glob": {
-                      "version": "7.0.5",
+                      "version": "7.1.1",
                       "from": "glob@>=7.0.5 <8.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
                     },
                     "graceful-fs": {
-                      "version": "4.1.4",
+                      "version": "4.1.11",
                       "from": "graceful-fs@>=4.1.2 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                     },
                     "graceful-readlink": {
                       "version": "1.0.1",
@@ -3001,11 +2995,6 @@
                       "version": "2.0.0",
                       "from": "has-ansi@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-                    },
-                    "has-color": {
-                      "version": "0.1.7",
-                      "from": "has-color@>=0.1.7 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                     },
                     "has-unicode": {
                       "version": "2.0.1",
@@ -3028,39 +3017,39 @@
                       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
                     },
                     "inflight": {
-                      "version": "1.0.5",
+                      "version": "1.0.6",
                       "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
                     },
                     "inherits": {
-                      "version": "2.0.1",
+                      "version": "2.0.3",
                       "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "ini": {
                       "version": "1.3.4",
                       "from": "ini@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                     },
+                    "is-my-json-valid": {
+                      "version": "2.15.0",
+                      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz"
+                    },
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
                       "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
                     },
-                    "is-my-json-valid": {
-                      "version": "2.13.1",
-                      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "from": "is-typedarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
                     },
                     "is-property": {
                       "version": "1.0.2",
                       "from": "is-property@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                    },
-                    "is-typedarray": {
-                      "version": "1.0.0",
-                      "from": "is-typedarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
@@ -3083,39 +3072,39 @@
                       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
                     "json-schema": {
-                      "version": "0.2.2",
-                      "from": "json-schema@0.2.2",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                      "version": "0.2.3",
+                      "from": "json-schema@0.2.3",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                     },
                     "json-stringify-safe": {
                       "version": "5.0.1",
                       "from": "json-stringify-safe@>=5.0.1 <5.1.0",
                       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
-                    "jsonpointer": {
-                      "version": "2.0.0",
-                      "from": "jsonpointer@2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-                    },
                     "jsprim": {
-                      "version": "1.3.0",
+                      "version": "1.3.1",
                       "from": "jsprim@>=1.2.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz"
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz"
+                    },
+                    "jsonpointer": {
+                      "version": "4.0.1",
+                      "from": "jsonpointer@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
                     },
                     "mime-db": {
-                      "version": "1.23.0",
-                      "from": "mime-db@>=1.23.0 <1.24.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                      "version": "1.25.0",
+                      "from": "mime-db@>=1.25.0 <1.26.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                     },
                     "mime-types": {
-                      "version": "2.1.11",
+                      "version": "2.1.13",
                       "from": "mime-types@>=2.1.7 <2.2.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz"
                     },
                     "minimatch": {
-                      "version": "3.0.2",
+                      "version": "3.0.3",
                       "from": "minimatch@>=3.0.2 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
                     },
                     "minimist": {
                       "version": "0.0.8",
@@ -3124,7 +3113,7 @@
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "from": "mkdirp@>=0.5.1 <0.6.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
                     },
                     "ms": {
@@ -3132,25 +3121,20 @@
                       "from": "ms@0.7.1",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     },
-                    "node-uuid": {
-                      "version": "1.4.7",
-                      "from": "node-uuid@>=1.4.7 <1.5.0",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-                    },
                     "nopt": {
                       "version": "3.0.6",
-                      "from": "nopt@>=3.0.1 <3.1.0",
+                      "from": "nopt@>=3.0.6 <3.1.0",
                       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
                     },
                     "npmlog": {
-                      "version": "3.1.2",
-                      "from": "npmlog@>=3.1.2 <3.2.0",
-                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz"
+                      "version": "4.0.2",
+                      "from": "npmlog@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz"
                     },
                     "number-is-nan": {
-                      "version": "1.0.0",
+                      "version": "1.0.1",
                       "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                     },
                     "oauth-sign": {
                       "version": "0.8.2",
@@ -3163,14 +3147,14 @@
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                     },
                     "once": {
-                      "version": "1.3.3",
+                      "version": "1.4.0",
                       "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
                     },
                     "path-is-absolute": {
-                      "version": "1.0.0",
+                      "version": "1.0.1",
                       "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                     },
                     "pinkie": {
                       "version": "2.0.4",
@@ -3187,40 +3171,45 @@
                       "from": "process-nextick-args@>=1.0.6 <1.1.0",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
+                    "punycode": {
+                      "version": "1.4.1",
+                      "from": "punycode@>=1.4.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                    },
                     "qs": {
-                      "version": "6.2.0",
-                      "from": "qs@>=6.2.0 <6.3.0",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
+                      "version": "6.3.0",
+                      "from": "qs@>=6.3.0 <6.4.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
                     },
                     "readable-stream": {
-                      "version": "2.1.4",
+                      "version": "2.2.2",
                       "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
-                    },
-                    "request": {
-                      "version": "2.73.0",
-                      "from": "request@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/request/-/request-2.73.0.tgz"
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
                     },
                     "rimraf": {
-                      "version": "2.5.3",
-                      "from": "rimraf@>=2.5.0 <2.6.0",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz"
+                      "version": "2.5.4",
+                      "from": "rimraf@>=2.5.4 <2.6.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
+                    },
+                    "request": {
+                      "version": "2.79.0",
+                      "from": "request@>=2.79.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz"
+                    },
+                    "signal-exit": {
+                      "version": "3.0.2",
+                      "from": "signal-exit@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
                     },
                     "semver": {
-                      "version": "5.2.0",
-                      "from": "semver@>=5.2.0 <5.3.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz"
+                      "version": "5.3.0",
+                      "from": "semver@>=5.3.0 <5.4.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
                     },
                     "set-blocking": {
                       "version": "2.0.0",
                       "from": "set-blocking@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-                    },
-                    "signal-exit": {
-                      "version": "3.0.0",
-                      "from": "signal-exit@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
@@ -3228,9 +3217,9 @@
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     },
                     "string-width": {
-                      "version": "1.0.1",
+                      "version": "1.0.2",
                       "from": "string-width@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -3253,44 +3242,44 @@
                       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                     },
                     "supports-color": {
-                      "version": "2.0.0",
-                      "from": "supports-color@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                      "version": "0.2.0",
+                      "from": "supports-color@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                     },
                     "tar": {
                       "version": "2.2.1",
-                      "from": "tar@>=2.2.0 <2.3.0",
+                      "from": "tar@>=2.2.1 <2.3.0",
                       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
                     },
-                    "tar-pack": {
-                      "version": "3.1.4",
-                      "from": "tar-pack@>=3.1.0 <3.2.0",
-                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz"
-                    },
                     "tough-cookie": {
-                      "version": "2.2.2",
-                      "from": "tough-cookie@>=2.2.0 <2.3.0",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+                      "version": "2.3.2",
+                      "from": "tough-cookie@>=2.3.0 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.3",
                       "from": "tunnel-agent@>=0.4.1 <0.5.0",
                       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
                     },
-                    "tweetnacl": {
-                      "version": "0.13.3",
-                      "from": "tweetnacl@>=0.13.0 <0.14.0",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
-                    },
                     "uid-number": {
                       "version": "0.0.6",
                       "from": "uid-number@>=0.0.6 <0.1.0",
                       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
                     },
+                    "tweetnacl": {
+                      "version": "0.14.5",
+                      "from": "tweetnacl@>=0.14.0 <0.15.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                    },
                     "util-deprecate": {
                       "version": "1.0.2",
                       "from": "util-deprecate@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    },
+                    "uuid": {
+                      "version": "3.0.1",
+                      "from": "uuid@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
                     },
                     "verror": {
                       "version": "1.3.6",
@@ -3312,27 +3301,15 @@
                       "from": "xtend@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     },
-                    "bl": {
-                      "version": "1.1.2",
-                      "from": "bl@>=1.1.2 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+                    "chalk": {
+                      "version": "1.1.3",
+                      "from": "chalk@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "dependencies": {
-                        "readable-stream": {
-                          "version": "2.0.6",
-                          "from": "readable-stream@>=2.0.5 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-                        }
-                      }
-                    },
-                    "dashdash": {
-                      "version": "1.14.0",
-                      "from": "dashdash@>=1.12.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "from": "assert-plus@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
@@ -3348,9 +3325,33 @@
                         }
                       }
                     },
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "from": "dashdash@>=1.12.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "from": "assert-plus@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.10.1",
+                      "from": "sshpk@>=1.7.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "from": "assert-plus@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        }
+                      }
+                    },
                     "rc": {
                       "version": "1.1.6",
-                      "from": "rc@>=1.1.0 <1.2.0",
+                      "from": "rc@>=1.1.6 <1.2.0",
                       "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
                       "dependencies": {
                         "minimist": {
@@ -3360,15 +3361,20 @@
                         }
                       }
                     },
-                    "sshpk": {
-                      "version": "1.8.3",
-                      "from": "sshpk@>=1.7.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
+                    "tar-pack": {
+                      "version": "3.3.0",
+                      "from": "tar-pack@>=3.3.0 <3.4.0",
+                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
                       "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "from": "assert-plus@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "once@>=1.3.3 <1.4.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "2.1.5",
+                          "from": "readable-stream@>=2.1.4 <2.2.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
                         }
                       }
                     }
@@ -3377,9 +3383,9 @@
               }
             },
             "debug": {
-              "version": "2.3.3",
+              "version": "2.6.0",
               "from": "debug@>=2.2.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.2",
@@ -3649,9 +3655,9 @@
                       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
                     },
                     "osenv": {
-                      "version": "0.1.3",
+                      "version": "0.1.4",
                       "from": "osenv@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
                       "dependencies": {
                         "os-homedir": {
                           "version": "1.0.2",
@@ -3666,9 +3672,9 @@
                       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
                     },
                     "write-file-atomic": {
-                      "version": "1.2.0",
+                      "version": "1.3.1",
                       "from": "write-file-atomic@>=1.1.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
                       "dependencies": {
                         "imurmurhash": {
                           "version": "0.1.4",
@@ -4190,7 +4196,7 @@
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "minimist@>=1.1.3 <2.0.0",
+                  "from": "minimist@1.2.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "xtend": {
@@ -4268,7 +4274,7 @@
         },
         "hoek": {
           "version": "4.1.0",
-          "from": "hoek@>=4.0.0 <5.0.0",
+          "from": "hoek@4.1.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.1.0.tgz"
         },
         "iron": {
@@ -4280,6 +4286,11 @@
           "version": "2.1.1",
           "from": "items@2.1.1",
           "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz"
+        },
+        "joi": {
+          "version": "10.0.1",
+          "from": "joi@10.0.1",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-10.0.1.tgz"
         },
         "mimos": {
           "version": "3.0.3",
@@ -4320,6 +4331,11 @@
           "version": "3.0.3",
           "from": "content@3.0.3",
           "resolved": "https://registry.npmjs.org/content/-/content-3.0.3.tgz"
+        },
+        "isemail": {
+          "version": "2.2.1",
+          "from": "isemail@2.2.1",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz"
         },
         "mime-db": {
           "version": "1.25.0",
@@ -4374,9 +4390,9 @@
               "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz"
             },
             "moment": {
-              "version": "2.17.0",
+              "version": "2.17.1",
               "from": "moment@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.0.tgz"
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.1.tgz"
             },
             "topo": {
               "version": "2.0.2",
@@ -4405,9 +4421,9 @@
       }
     },
     "joi": {
-      "version": "10.0.1",
+      "version": "10.1.0",
       "from": "joi@>=10.0.1 <11.0.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-10.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-10.1.0.tgz",
       "dependencies": {
         "hoek": {
           "version": "4.1.0",
@@ -4421,15 +4437,20 @@
         },
         "items": {
           "version": "2.1.1",
-          "from": "items@2.1.1",
+          "from": "items@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz"
         },
         "topo": {
           "version": "2.0.2",
-          "from": "topo@2.0.2",
+          "from": "topo@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz"
         }
       }
+    },
+    "keypair": {
+      "version": "1.0.1",
+      "from": "keypair@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.1.tgz"
     },
     "load-grunt-tasks": {
       "version": "3.5.2",
@@ -4734,9 +4755,9 @@
       "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.6.tgz",
       "dependencies": {
         "intel": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "from": "intel@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/intel/-/intel-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/intel/-/intel-1.1.2.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
@@ -4984,9 +5005,9 @@
           }
         },
         "debug": {
-          "version": "2.3.3",
+          "version": "2.6.0",
           "from": "debug@>=2.2.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.2",
@@ -5079,9 +5100,9 @@
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "dependencies": {
         "mute-stream": {
-          "version": "0.0.6",
+          "version": "0.0.7",
           "from": "mute-stream@>=0.0.4 <0.1.0",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz"
         }
       }
     },
@@ -5213,9 +5234,9 @@
                   }
                 },
                 "jsonpointer": {
-                  "version": "4.0.0",
+                  "version": "4.0.1",
                   "from": "jsonpointer@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
@@ -5328,9 +5349,9 @@
                   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                 },
                 "tweetnacl": {
-                  "version": "0.14.3",
+                  "version": "0.14.5",
                   "from": "tweetnacl@>=0.14.0 <0.15.0",
-                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
                 },
                 "jodid25519": {
                   "version": "1.0.2",
@@ -5418,9 +5439,9 @@
       }
     },
     "sinon": {
-      "version": "1.17.6",
+      "version": "1.17.7",
       "from": "sinon@>=1.15.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.6.tgz",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
       "dependencies": {
         "formatio": {
           "version": "1.1.1",
@@ -5571,9 +5592,9 @@
       }
     },
     "urijs": {
-      "version": "1.18.3",
+      "version": "1.18.4",
       "from": "urijs@>=1.16.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.18.3.tgz"
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.18.4.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "hapi": "16.0.0",
     "hapi-hpkp": "1.0.0",
     "joi": "^10.0.1",
+    "keypair": "^1.0.1",
     "mozlog": "^2.0.3",
     "mysql": "^2.5.5",
     "mysql-patcher": "^0.7.0",
@@ -43,7 +44,6 @@
   "devDependencies": {
     "blanket": "1.1.6",
     "eslint-config-fxa": "^1.8.0",
-    "generate-rsa-keypair": "0.1.1",
     "grunt": "^1.0.1",
     "grunt-bump": "0.8.0",
     "grunt-conventional-changelog": "^1.1.0",

--- a/scripts/gen_keys.js
+++ b/scripts/gen_keys.js
@@ -21,7 +21,7 @@
 
 const fs = require('fs');
 const assert = require('assert');
-const generateRSAKeypair = require('generate-rsa-keypair');
+const generateRSAKeypair = require('keypair');
 const JwTool = require('fxa-jwtool');
 
 const keyPath = './config/key.json';

--- a/test/api.js
+++ b/test/api.js
@@ -6,7 +6,7 @@ const url = require('url');
 const assert = require('insist');
 const nock = require('nock');
 const buf = require('buf').hex;
-const generateRSAKeypair = require('generate-rsa-keypair');
+const generateRSAKeypair = require('keypair');
 const JWTool = require('fxa-jwtool');
 
 const auth = require('../lib/auth');


### PR DESCRIPTION
This PR switches from a native module to a pure JS module. No build dependencies necessary!