### PR TITLE
fix(travis): run tests with 6 and 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
   - '6'
+  - '8'
 
 dist: trusty
 sudo: true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "grunt server --node-env=dev",
     "test": "NODE_ENV=test scripts/test-local.sh",
-    "outdated": "npm outdated --depth 0",
+    "outdated": "npm outdated --depth 0 || exit 0",
     "postinstall": "node scripts/gen_keys",
     "shrink": "npmshrink"
   },


### PR DESCRIPTION
r? - @vbudhram 

The `|| exit 0` is so that `npm run outdated` acts the same with npm@5 (which will exit non-zero in cases that npm < 5 did not).