### PR TITLE
feat(keys): Check lastAuthAt freshness when fetching key data.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -127,6 +127,12 @@ const conf = convict({
       format: 'duration',
       default: '15 minutes',
       env: 'FXA_EXPIRATION_CODE'
+    },
+    keyDataAuth: {
+      doc: 'Key data can only be fetched if lastAuthAt is within this duration',
+      format: 'duration',
+      default: '1 hour',
+      env: 'FXA_EXPIRATION_KEY_DATA_AUTH'
     }
   },
   refreshToken: {

--- a/lib/error.js
+++ b/lib/error.js
@@ -116,6 +116,7 @@ AppError.invalidAssertion = function invalidAssertion() {
     message: 'Invalid assertion'
   });
 };
+
 AppError.unknownCode = function unknownCode(code) {
   return new AppError({
     code: 400,
@@ -261,6 +262,17 @@ AppError.missingPkceParameters = function missingPkceParameters() {
     error: 'PKCE parameters missing',
     errno: 118,
     message: 'Public clients require PKCE OAuth parameters'
+  });
+};
+
+AppError.staleAuthAt = function staleAuthAt(authAt) {
+  return new AppError({
+    code: 401,
+    error: 'Bad Request',
+    errno: 119,
+    message: 'Stale authentication timestamp'
+  }, {
+    authAt: authAt
   });
 };
 

--- a/lib/routes/key_data.js
+++ b/lib/routes/key_data.js
@@ -11,6 +11,9 @@ const P = require('../promise');
 const validators = require('../validators');
 const verify = require('../browserid');
 const Scope = require('../scope');
+const config = require('../config');
+
+const AUTH_EXPIRES_AFTER_MS = config.get('expiration.keyDataAuth');
 
 /**
  * We're using a static value for key material on purpose, in future this value can read from the DB.
@@ -70,6 +73,10 @@ module.exports = {
       const assertionData = results[0];
       const scopeResults = results[1];
       const response = {};
+
+      if (assertionData['fxa-lastAuthAt'] < Date.now() - AUTH_EXPIRES_AFTER_MS) {
+        throw AppError.staleAuthAt(assertionData['fxa-lastAuthAt']);
+      }
 
       scopeResults.forEach((keyScope) => {
         response[keyScope.scope] = {

--- a/test/api.js
+++ b/test/api.js
@@ -21,13 +21,25 @@ const assertSecurityHeaders = require('./lib/util').assertSecurityHeaders;
 
 const USERID = unique(16).toString('hex');
 const VEMAIL = unique(4).toString('hex') + '@mozilla.com';
+const AUTH_AT = Date.now();
+const STALE_AUTH_AT = Date.now() - (2 * 24 * 60 * 60 * 1000);
 const VERIFY_GOOD = JSON.stringify({
   status: 'okay',
   email: USERID + '@' + config.get('browserid.issuer'),
   issuer: config.get('browserid.issuer'),
   idpClaims: {
     'fxa-verifiedEmail': VEMAIL,
-    'fxa-lastAuthAt': 123456,
+    'fxa-lastAuthAt': AUTH_AT,
+    'fxa-generation': 123456
+  }
+});
+const VERIFY_GOOD_BUT_STALE = JSON.stringify({
+  status: 'okay',
+  email: USERID + '@' + config.get('browserid.issuer'),
+  issuer: config.get('browserid.issuer'),
+  idpClaims: {
+    'fxa-verifiedEmail': VEMAIL,
+    'fxa-lastAuthAt': STALE_AUTH_AT,
     'fxa-generation': 123456
   }
 });
@@ -1226,7 +1238,7 @@ describe('/v1', function() {
               assert.equal(res.result.access_token.length,
                 config.get('unique.token') * 2);
               assert.equal(res.result.scope, 'foo bar');
-              assert.equal(res.result.auth_at, 123456);
+              assert.equal(res.result.auth_at, AUTH_AT);
             });
           });
         });
@@ -1262,7 +1274,7 @@ describe('/v1', function() {
               assert.equal(res.result.refresh_token.length,
                 config.get('unique.token') * 2);
               assert.equal(res.result.scope, 'foo bar');
-              assert.equal(res.result.auth_at, 123456);
+              assert.equal(res.result.auth_at, AUTH_AT);
             });
           });
         });
@@ -2334,6 +2346,20 @@ describe('/v1', function() {
             assert.equal(res.statusCode, 200);
             assertSecurityHeaders(res);
             assert.equal(Object.keys(res.result).length, 0, 'no scoped keys');
+          });
+      });
+
+      it('fails for assertions with lastAuthAt too far in the past', () => {
+        genericRequest.payload.client_id = NO_KEY_SCOPES_CLIENT_ID;
+
+        mockAssertion().reply(200, VERIFY_GOOD_BUT_STALE);
+        return Server.api.post(genericRequest)
+          .then((res) => {
+            assert.equal(res.statusCode, 401);
+            assertSecurityHeaders(res);
+            const body = res.result;
+            assert.equal(body.errno, 119);
+            assert.equal(body.message, 'Stale authentication timestamp');
           });
       });
     });


### PR DESCRIPTION
For a future world where the `keyRotationSecret` is actually a secret value, we should only return it to users who have proved that they *recently* know the account password.  @vladikoff r?