### PR TITLE
feat(openid): Allow untrusted reliers to request `openid` scope.

### DIFF
--- a/lib/routes/authorization.js
+++ b/lib/routes/authorization.js
@@ -28,6 +28,7 @@ const PKCE_CODE_CHALLENGE_LENGTH = 43;
 const MAX_TTL_S = config.get('expiration.accessToken') / 1000;
 
 const UNTRUSTED_CLIENT_ALLOWED_SCOPES = [
+  'openid',
   'profile:uid',
   'profile:email',
   'profile:display_name'

--- a/test/api.js
+++ b/test/api.js
@@ -1835,6 +1835,16 @@ describe('/v1', function() {
         });
       });
 
+      it('should be available to untrusted reliers', function() {
+        var client = clientByName('Untrusted');
+        return newToken({ scope: 'openid' }, { client_id: client.id }).then(function(res) {
+          assert.equal(res.statusCode, 200);
+          assertSecurityHeaders(res);
+          assert(res.result.access_token);
+          assert(res.result.id_token);
+        });
+      });
+
     });
 
   });


### PR DESCRIPTION
As noted in https://github.com/mozilla/fxa-oauth-server/issues/515, untrusted reliers currently can't request the `openid` scope, and hence can't use the OIDC id_token flow.  I don't see any risk to allowing them to request it, since the id_token doesn't directly contain any profile information, they still have to request other scopes like `profile:email` in order to be able to access profile data.

@vbudhram r?