### PR TITLE
fix(scripts): Fix varname typo in test runner script.

### DIFF
--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -8,7 +8,7 @@ set -u
 
 GLOB=$*
 if [ -z "$GLOB" ]; then
-  GLOG="test/*.js test/routes/*.js test/db/*.js"
+  GLOB="test/*.js test/routes/*.js test/db/*.js"
 fi
 
 DEFAULT_ARGS="-R spec --timeout 20000 --recursive"


### PR DESCRIPTION
Sorry Glog, but I'm pretty sure you're a typo; @mozilla/fxa-devs r?