### PR TITLE
fix(mysql): Correctly aggregate tokens by clientid.

### DIFF
--- a/lib/db/mysql/index.js
+++ b/lib/db/mysql/index.js
@@ -193,7 +193,7 @@ const QUERY_PURGE_EXPIRED_TOKENS = 'DELETE FROM tokens WHERE clientId NOT IN (?)
 // Returns the most recent token used with a client name and client id.
 // Does not include clients that canGrant.
 const QUERY_ACTIVE_CLIENT_TOKENS_BY_UID =
-  'SELECT tokens.clientId, tokens.createdAt, tokens.scope, clients.name ' +
+  'SELECT tokens.clientId AS id, tokens.createdAt, tokens.scope, clients.name ' +
   'FROM tokens LEFT OUTER JOIN clients ON clients.id = tokens.clientId ' +
   'WHERE tokens.userId=? AND tokens.expiresAt > NOW() AND clients.canGrant = 0;';
 const DELETE_ACTIVE_TOKENS_BY_CLIENT_AND_UID =


### PR DESCRIPTION
It turns out that the mysql variant of https://github.com/mozilla/fxa-oauth-server-private/pull/9 was buggy, and would aggregate all clients into a single record with id of "undefined" rather than producing one record per client id.

It's a simple fix that we should point-release to train-115; @vladikoff r?

But it's also an indication that the CI in fxa-oauth-server-private is only running tests against the in-memory db, not against mysql.  @jrgm @jbuck which do you think would be a simpler way to fix that - having circle run tests against the mysql backend, or adding travis to the private repo?