### PR TITLE
feat(codes): Delete authorization codes when revoking client access.

### DIFF
--- a/lib/db/memory.js
+++ b/lib/db/memory.js
@@ -292,13 +292,13 @@ MemoryStore.prototype = {
   },
 
   /**
-   * Delete all non-expired tokens for some clientId and uid.
+   * Delete all authorization grants for some clientId and uid.
    *
    * @param {String} clientId Client ID
    * @param {String} uid User Id as Hex
-   * @returns {Promise}
+   e @returns {Promise}
    */
-  deleteActiveClientTokens: function deleteActiveClientTokens(clientId, uid) {
+  deleteClientAuthorization: function deleteClientAuthorization(clientId, uid) {
     if (! clientId || ! uid) {
       return P.reject(new Error('clientId and uid are required'));
     }
@@ -314,6 +314,7 @@ MemoryStore.prototype = {
       }
     }
 
+    deleteToken(this.codes);
     deleteToken(this.tokens);
     deleteToken(this.refreshTokens);
 

--- a/lib/routes/client-tokens/delete.js
+++ b/lib/routes/client-tokens/delete.js
@@ -12,7 +12,7 @@ module.exports = {
   },
   handler: function activeServices(req, reply) {
     var clientId = req.params.client_id;
-    return db.deleteActiveClientTokens(clientId, req.auth.credentials.user)
+    return db.deleteClientAuthorization(clientId, req.auth.credentials.user)
       .done(function() {
         reply({});
       }, reply);

--- a/test/db/index.js
+++ b/test/db/index.js
@@ -605,12 +605,12 @@ describe('db', function() {
       });
     });
 
-    describe('deleteActiveClientTokens', function() {
+    describe('deleteClientAuthorization', function() {
       var clientId = buf(randomString(8));
       var userId = buf(randomString(16));
 
       it('should delete client tokens', function() {
-        return db.deleteActiveClientTokens(clientId, userId)
+        return db.deleteClientAuthorization(clientId, userId)
           .then(
             function(result) {
               assert.ok(result);


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1320218#c3, revoking access for an OAuth client should revoke everything, including any as-yet-unclaimed authorization codes.