### PR TITLE
Dockerpush fix docker use base builder run npm ls production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,10 @@ jobs:
           command: docker build -f Dockerfile-build -t fxa-oauth-server:build .
 
       - run:
+          name: Check npm install
+          command: docker run --rm -it fxa-oauth-server:build npm ls --production
+
+      - run:
           name: Build test container image
           command: docker build -f Dockerfile-test -t fxa-oauth-server:test .
 

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -1,8 +1,9 @@
-FROM node:8-alpine
+FROM node:8-alpine AS builder
 
 RUN npm install -g npm@6 && rm -rf ~app/.npm /tmp/*
 
-RUN apk add --no-cache git
+RUN apk add --no-cache git && \
+    apk add --repository http://dl-cdn.alpinelinux.org/alpine/v3.5/community/ --no-cache --virtual .build-deps git python make g++
 
 RUN addgroup -g 10001 app && \
     adduser -D -G app -h /app -u 10001 app
@@ -22,3 +23,24 @@ COPY scripts/gen_keys.js scripts/gen_keys.js
 RUN npm install --production && rm -rf ~app/.npm /tmp/*
 
 COPY . /app
+
+
+# Build final image by copying from builder
+FROM node:8-alpine
+
+RUN npm install -g npm@6 && rm -rf ~app/.npm /tmp/*
+
+RUN apk add --no-cache git
+
+RUN addgroup -g 10001 app && \
+    adduser -D -G app -h /app -u 10001 app
+WORKDIR /app
+
+# S3 bucket in Cloud Services prod IAM
+ADD https://s3.amazonaws.com/dumb-init-dist/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+
+USER app
+
+COPY --from=builder --chown=app /app/ /app/

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,2 +1,5 @@
 FROM fxa-oauth-server:build
+USER root
+RUN apk add --repository http://dl-cdn.alpinelinux.org/alpine/v3.5/community/ --no-cache --virtual .build-deps git python make g++
+USER app
 RUN npm install


### PR DESCRIPTION
This is similar to mozilla/fxa-profile-server#330. It builds from a base image that has tools that can build binary node extensions, and secondly, checks the install with `npm install --production`.

The net gain is 3MB from the production image. (A `--squash` would recoup about 8MB from that image, but not bothering with `--squash` in this PR).

r? - @vladikoff 