### PR TITLE
fix(config): For dev, the openid issuer is http://127.0.0.1:3030

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -142,6 +142,7 @@
     "fmt": "pretty"
   },
   "openid": {
+    "issuer": "http://127.0.0.1:3030",
     "keyFile": "../config/key.json",
     "key": {}
   },


### PR DESCRIPTION
This enables the content server functional tests to run locally
when using fxa-local-dev

fixes mozilla/fxa-content-server#6362

@vladikoff - r?