### PR TITLE
fix(doc): Putting a little emphasis on email first

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -291,9 +291,9 @@ content-server page.
 - `access_type`: Optional. If provided, should be `online` or `offline`. `offline` will result in a refresh_token being provided, so that the access_token can be refreshed after it expires.
 - `action`: Optional. If provided, should be `email`, `signup`, `signin`, or `force_auth`. Send to improve the user experience.
   - If unspecified then Firefox Accounts will try choose intelligently between `signin` and `signup` based on the user's browser state.
-  - `email` triggers the email-first flow, which uses the email address to determine whether to display signup or signin.
-  - `signin` triggers the signin flow.
-  - `signup` triggers the signup flow.
+  - `email` triggers the email-first flow, which uses the email address to determine whether to display signup or signin. This is becoming the **preferred** action and is slowly replacing `signin` and `signup`.
+  - `signin` triggers the signin flow. (will become depricated and replaced by `email`)
+  - `signup` triggers the signup flow. (will become depricated and replaced by `email`)
   - `force_auth` requires the user to sign in using the address specified in `email`.
 - `email`: Optional if `action` is `email`, `signup` or `signin`. Required if `action`
   is `force_auth`.


### PR DESCRIPTION
I was going to link to this page and I realized we didn't put any emphasis on email first flow so I thought I would add that. I believe we all want to make it clear that it is the new preferred method for authenticating users.