### PR TITLE
fix(clients): match the notes client with fxa-dev and other envs

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -47,7 +47,7 @@
       "canGrant": false
     },
     {
-      "id": "d5d74070a481bc10",
+      "id": "7f368c6886429f19",
       "name": "Firefox Notes Android Dev",
       "hashedSecret": "9c716ed2927c96cdc0fb7efe57d5f124fb4161066c1ff7f4263069822256ec3f",
       "redirectUri": "https://mozilla.github.io/notes/fxa/android-redirect.html",


### PR DESCRIPTION
ref https://github.com/mozilla/fxa-dev/blob/85b8742e2d8201e13fe1d4563f243e2e0034877e/roles/oauth/templates/config.json.j2#L50

ref https://github.com/mozilla/fxa-content-server/issues/6345