### PR TITLE
feat(tokens): add associated refresh tokens properties to access tokens

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,3 +5,6 @@ extends: plugin:fxa/server
 rules:
   handle-callback-err: 0
   semi: [2, "always"]
+
+parserOptions:
+  ecmaVersion: 2017

--- a/lib/db/memory.js
+++ b/lib/db/memory.js
@@ -244,7 +244,8 @@ MemoryStore.prototype = {
       createdAt: now,
       // ttl is in seconds
       expiresAt: new Date(+now + (vals.ttl * 1000 || MAX_TTL)),
-      token: encrypt.hash(token)
+      associatedRefreshToken: vals.associatedRefreshToken,
+      token: encrypt.hash(token),
     };
     var ret = clone(t);
     this.tokens[unbuf(t.token)] = t;

--- a/lib/db/mysql/index.js
+++ b/lib/db/mysql/index.js
@@ -169,7 +169,7 @@ const QUERY_CODE_INSERT =
   'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
 const QUERY_ACCESS_TOKEN_INSERT =
   'INSERT INTO tokens (clientId, userId, email, scope, type, expiresAt, ' +
-  'token) VALUES (?, ?, ?, ?, ?, ?, ?)';
+  'associatedRefreshToken, token) VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
 const QUERY_REFRESH_TOKEN_INSERT =
   'INSERT INTO refreshTokens (clientId, userId, email, scope, token) VALUES ' +
   '(?, ?, ?, ?, ?)';
@@ -423,7 +423,8 @@ MysqlStore.prototype = {
       scope: Scope(vals.scope),
       token: unique.token(),
       type: 'bearer',
-      expiresAt: vals.expiresAt || new Date(Date.now() + (vals.ttl  * 1000 || MAX_TTL))
+      expiresAt: vals.expiresAt || new Date(Date.now() + (vals.ttl  * 1000 || MAX_TTL)),
+      associatedRefreshToken: vals.associatedRefreshToken ? buf(vals.associatedRefreshToken) : null
     };
     return this._write(QUERY_ACCESS_TOKEN_INSERT, [
       t.clientId,
@@ -432,6 +433,7 @@ MysqlStore.prototype = {
       t.scope.toString(),
       t.type,
       t.expiresAt,
+      t.associatedRefreshToken,
       encrypt.hash(t.token)
     ]).then(function() {
       return t;

--- a/lib/db/mysql/patch.js
+++ b/lib/db/mysql/patch.js
@@ -6,4 +6,4 @@
 // Update this if you add a new patch, and don't forget to update
 // the documentation for the current schema in ../schema.sql.
 
-module.exports.level = 21;
+module.exports.level = 22;

--- a/lib/db/mysql/patches/patch-021-022.sql
+++ b/lib/db/mysql/patches/patch-021-022.sql
@@ -1,0 +1,5 @@
+ALTER TABLE tokens
+ADD COLUMN associatedRefreshToken BINARY(32),
+ADD CONSTRAINT FOREIGN KEY (associatedRefreshToken) REFERENCES refreshTokens(token) ON DELETE CASCADE;
+
+UPDATE dbMetadata SET value = '22' WHERE name = 'schema-patch-level';

--- a/lib/db/mysql/patches/patch-022-021.sql
+++ b/lib/db/mysql/patches/patch-022-021.sql
@@ -1,0 +1,4 @@
+-- ALTER TABLE tokens
+-- DROP COLUMN associatedRefreshToken;
+
+-- UPDATE dbMetadata SET value = '21' WHERE name = 'schema-patch-level';

--- a/lib/db/mysql/schema.sql
+++ b/lib/db/mysql/schema.sql
@@ -46,7 +46,9 @@ CREATE TABLE IF NOT EXISTS tokens (
   scope VARCHAR(256) NOT NULL,
   createdAt TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   expiresAt TIMESTAMP NOT NULL,
-  INDEX idx_expiresAt(expiresAt)
+  INDEX idx_expiresAt(expiresAt),
+  associatedRefreshToken BINARY(32),
+  FOREIGN KEY (associatedRefreshToken) REFERENCES refreshTokens(token) ON DELETE CASCADE
 ) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS developers (

--- a/lib/routes/token.js
+++ b/lib/routes/token.js
@@ -230,6 +230,9 @@ module.exports = {
       }
     })
     .then(function(vals) {
+      if (params.grant_type === GRANT_REFRESH_TOKEN) {
+        vals.associatedRefreshToken = encrypt.hash(params.refresh_token);
+      }
       vals.ttl = params.ttl;
       if (vals.scope && Scope(vals.scope).has(SCOPE_OPENID)) {
         vals.idToken = true;
@@ -465,42 +468,31 @@ function generateIdToken(options) {
   return ID_TOKEN_KEY.sign(claims);
 }
 
-function generateTokens(options) {
+async function generateTokens(options) {
   // we always are generating an access token here
   // but depending on options, we may also be generating a refresh_token
-  var promises = {
-    access: db.generateAccessToken(options)
-  };
+  const json = {};
   if (options.offline) {
-    promises.refresh = db.generateRefreshToken(options);
+    const refresh = await db.generateRefreshToken(options);
+    json.refresh_token = refresh.token.toString('hex');
+    options.associatedRefreshToken = encrypt.hash(refresh.token);
   }
-  if (options.idToken) {
-    promises.idToken = generateIdToken(options);
-  }
-  return P.props(promises).then(function(result) {
-    var access = result.access;
-    var refresh = result.refresh;
-    var idToken = result.idToken;
-
-    var json = {
-      access_token: access.token.toString('hex'),
-      token_type: access.type,
-      scope: Scope(access.scope).toString()
-    };
-    if (options.authAt) {
-      json.auth_at = options.authAt;
-    }
-    json.expires_in = options.ttl;
-    if (refresh) {
-      json.refresh_token = refresh.token.toString('hex');
-    }
-    if (idToken) {
-      json.id_token = idToken;
-    }
-    if (options.keysJwe) {
-      json.keys_jwe = options.keysJwe;
-    }
-    return json;
+  const access = await db.generateAccessToken(options);
+  Object.assign(json, {
+    access_token: access.token.toString('hex'),
+    token_type: access.type,
+    scope: Scope(access.scope).toString()
   });
+  if (options.authAt) {
+    json.auth_at = options.authAt;
+  }
+  json.expires_in = options.ttl;
+  if (options.idToken) {
+    const idToken = await generateIdToken(options);
+    json.id_token = idToken;
+  }
+  if (options.keysJwe) {
+    json.keys_jwe = options.keysJwe;
+  }
+  return json;
 }
-

--- a/test/api.js
+++ b/test/api.js
@@ -1464,6 +1464,9 @@ describe('/v1', function() {
                 config.get('unique.token') * 2);
               assert.equal(res.result.scope, 'foo bar');
               assert.equal(res.result.auth_at, AUTH_AT);
+              return db.getAccessToken(encrypt.hash(res.result.access_token)).then(function(tok) {
+                assert.deepEqual(tok.associatedRefreshToken, encrypt.hash(res.result.refresh_token));
+              });
             });
           });
         });
@@ -1559,6 +1562,9 @@ describe('/v1', function() {
             assert(res.result.expires_in);
             assert(res.result.access_token);
             assert.equal(res.result.refresh_token, undefined);
+            return db.getAccessToken(encrypt.hash(res.result.access_token)).then(function(tok) {
+              assert.deepEqual(tok.associatedRefreshToken, encrypt.hash(refresh));
+            });
           });
         });
 


### PR DESCRIPTION
Allows associating an access token to a refresh token, this is a prerequisite for the new OAuth device API.