### PR TITLE
fix(authorization): Correctly handle non-existing URL scopes during authorization

### DIFF
--- a/lib/routes/authorization.js
+++ b/lib/routes/authorization.js
@@ -238,7 +238,7 @@ module.exports = {
             // so avoid trips to the DB for common scopes like 'profile'.
             if (scope.startsWith('https://')) {
               return db.getScope(scope).then(s => {
-                if (s.hasScopedKeys) {
+                if (s && s.hasScopedKeys) {
                   exitEarly = true;
                   throw AppError.invalidAssertion();
                 }

--- a/test/api.js
+++ b/test/api.js
@@ -545,6 +545,20 @@ describe('/v1', function() {
         });
       });
 
+      it('succeeds when fxa-tokenVerified is false and an unknown URL scope is requested', function() {
+        mockAssertion().reply(200, VERIFY_GOOD_BUT_UNVERIFIED);
+        return Server.api.post({
+          url: '/authorization',
+          payload: authParams({
+            client_id: SCOPED_CLIENT_ID,
+            scope: 'https://example.com/unknown-scope'
+          })
+        }).then(function(res) {
+          assert.equal(res.statusCode, 200);
+          assertSecurityHeaders(res);
+        });
+      });
+
     });
 
     describe('?redirect_uri', function() {


### PR DESCRIPTION
Fixes #593; @shane-tomlinson r?