### PR TITLE
fix(key-data): Correctly handle non-existent scopes when finding key data

### DIFF
--- a/lib/routes/key_data.js
+++ b/lib/routes/key_data.js
@@ -55,7 +55,7 @@ module.exports = {
           const allowedScopes = ScopeSet.fromString(client.allowedScopes);
           const scopeLookups = requestedScopes.filtered(allowedScopes).getScopeValues().map(s => db.getScope(s));
           return P.all(scopeLookups).then((result) => {
-            return result.filter((s) => !! s.hasScopedKeys);
+            return result.filter((s) => !! (s && s.hasScopedKeys));
           });
         } else {
           logger.debug('keyDataRoute.clientNotFound', { id: req.payload.client_id });

--- a/test/api.js
+++ b/test/api.js
@@ -2642,7 +2642,7 @@ describe('/v1', function() {
           .then((res) => {
             assert.equal(res.statusCode, 200);
             assertSecurityHeaders(res);
-            assert.equal(Object.keys(res.result).length, 2, 'only one scope returned');
+            assert.equal(Object.keys(res.result).length, 2, 'two scopes returned');
 
             const keyOne = res.result[SCOPE_CAN_SCOPE_KEY];
             const keyTwo = res.result[ANOTHER_CAN_SCOPE_KEY];
@@ -2670,7 +2670,7 @@ describe('/v1', function() {
           });
       });
 
-      it('fails with a non-scoped-key scope ', () => {
+      it('succeeds with a non-scoped-key scope', () => {
         genericRequest.payload.scope = 'https://identity.mozilla.com/apps/sample-scope';
         mockAssertion().reply(200, VERIFY_GOOD);
         return Server.api.post(genericRequest)
@@ -2678,6 +2678,17 @@ describe('/v1', function() {
             assert.equal(res.statusCode, 200);
             assertSecurityHeaders(res);
             assert.equal(Object.keys(res.result).length, 0, 'no scoped keys');
+          });
+      });
+
+      it('succeeds with scopes that arent explicitly defined in config', () => {
+        genericRequest.payload.scope += ' kv';
+        mockAssertion().reply(200, VERIFY_GOOD);
+        return Server.api.post(genericRequest)
+          .then((res) => {
+            assert.equal(res.statusCode, 200);
+            assertSecurityHeaders(res);
+            assert.deepEqual(Object.keys(res.result), [SCOPE_CAN_SCOPE_KEY], 'undefined scope is ignored');
           });
       });
 


### PR DESCRIPTION
This is basically the same bug as https://github.com/mozilla/fxa-oauth-server/pull/594/files except in the `/key-data` endpoint.  @mozilla/fxa-devs r?