### PR TITLE
fix(profile): remove the `profileChangedAt` colum on tokens table

### DIFF
--- a/lib/db/memory.js
+++ b/lib/db/memory.js
@@ -244,8 +244,7 @@ MemoryStore.prototype = {
       createdAt: now,
       // ttl is in seconds
       expiresAt: new Date(+now + (vals.ttl * 1000 || MAX_TTL)),
-      token: encrypt.hash(token),
-      profileChangedAt: vals.profileChangedAt || 0
+      token: encrypt.hash(token)
     };
     var ret = clone(t);
     this.tokens[unbuf(t.token)] = t;

--- a/lib/db/mysql/index.js
+++ b/lib/db/mysql/index.js
@@ -177,7 +177,7 @@ const QUERY_CODE_INSERT =
   'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
 const QUERY_ACCESS_TOKEN_INSERT =
   'INSERT INTO tokens (clientId, userId, email, scope, type, expiresAt, ' +
-  'token, profileChangedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
+  'token) VALUES (?, ?, ?, ?, ?, ?, ?)';
 const QUERY_REFRESH_TOKEN_INSERT =
   'INSERT INTO refreshTokens (clientId, userId, email, scope, token, profileChangedAt) VALUES ' +
   '(?, ?, ?, ?, ?, ?)';

--- a/lib/db/mysql/patch.js
+++ b/lib/db/mysql/patch.js
@@ -6,4 +6,4 @@
 // Update this if you add a new patch, and don't forget to update
 // the documentation for the current schema in ../schema.sql.
 
-module.exports.level = 23;
+module.exports.level = 24;

--- a/lib/db/mysql/patches/patch-023-024.sql
+++ b/lib/db/mysql/patches/patch-023-024.sql
@@ -1,0 +1,8 @@
+-- This removes the `profileChangedAt` column on the tokens table.
+-- Since the tokens table is so large, this migration causes some issues.
+-- When the tokens get purged and the table is a bit smaller we can attempt to
+-- add this column.
+ALTER TABLE tokens DROP COLUMN profileChangedAt,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+UPDATE dbMetadata SET value = '24' WHERE name = 'schema-patch-level';

--- a/lib/db/mysql/patches/patch-024-023.sql
+++ b/lib/db/mysql/patches/patch-024-023.sql
@@ -1,0 +1,4 @@
+-- ALTER TABLE tokens ADD COLUMN profileChangedAt BIGINT DEFAULT NULL,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- UPDATE dbMetadata SET value = '23`' WHERE name = 'schema-patch-level';

--- a/lib/db/mysql/schema.sql
+++ b/lib/db/mysql/schema.sql
@@ -45,7 +45,6 @@ CREATE TABLE IF NOT EXISTS tokens (
   scope VARCHAR(256) NOT NULL,
   createdAt TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   expiresAt TIMESTAMP NOT NULL,
-  profileChangedAt BIGINT DEFAULT NULL,
   INDEX idx_expiresAt(expiresAt)
 ) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 

--- a/test/api.js
+++ b/test/api.js
@@ -2886,7 +2886,11 @@ describe('/v1', function() {
           assert.equal(res.result.client_id, clientId);
           assert.equal(res.result.scope[0], 'profile');
           assert.equal(res.result.email, undefined);
-          assert.equal(res.result.profile_changed_at, PROFILE_CHANGED_AT_LATER_TIME, 'profile changed at is correct');
+
+          // profileChangedAt (profile_changed_at) was introduced on the tokens table to
+          // help detect stale profile data, but we couldn't complete the migration at the time.
+          // If/when migration gets sorted out, we can check for actual value.
+          assert.equal(res.result.profile_changed_at, undefined, 'profile changed at is not set');
         });
       });
     });


### PR DESCRIPTION
Connects to https://github.com/mozilla/fxa-oauth-server/issues/620

This PR removes the `profileChangedAt` column on the tokens table. Is this what you had in mind @rfk?