### PR TITLE
fix(db): Restore foreign key constraints on core tables.

### DIFF
--- a/lib/db/mysql/patch.js
+++ b/lib/db/mysql/patch.js
@@ -6,4 +6,4 @@
 // Update this if you add a new patch, and don't forget to update
 // the documentation for the current schema in ../schema.sql.
 
-module.exports.level = 24;
+module.exports.level = 25;

--- a/lib/db/mysql/patches/patch-024-025.sql
+++ b/lib/db/mysql/patches/patch-024-025.sql
@@ -1,0 +1,26 @@
+-- This restores some of the FOREIGN KEY constraints that were
+-- dropped in migration #23.  They unexpectedly caused MySQL to
+-- change its query plan and start scanning large chunks of the
+-- `tokens` table.  More context here:
+--
+--     https://github.com/mozilla/fxa-auth-server/issues/2695
+--
+-- We'll remove them again in a follow-up migration, and adjust
+-- the queries to ensure they use the right indexes.  For now
+-- we're just putting them back so that the alleged state of
+-- the db matches what's in production.
+
+SET FOREIGN_KEY_CHECKS=0;
+
+ALTER TABLE refreshTokens ADD FOREIGN KEY (clientId) REFERENCES clients(id) ON DELETE CASCADE,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+ALTER TABLE codes ADD FOREIGN KEY (clientId) REFERENCES clients(id) ON DELETE CASCADE,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+ALTER TABLE tokens ADD FOREIGN KEY (clientId) REFERENCES clients(id) ON DELETE CASCADE,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+SET FOREIGN_KEY_CHECKS=1;
+
+UPDATE dbMetadata SET value = '25' WHERE name = 'schema-patch-level';

--- a/lib/db/mysql/patches/patch-025-024.sql
+++ b/lib/db/mysql/patches/patch-025-024.sql
@@ -1,0 +1,11 @@
+
+-- ALTER TABLE refreshTokens DROP FOREIGN KEY refreshTokens_ibfk_1,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- ALTER TABLE codes DROP FOREIGN KEY codes_ibfk_1,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- ALTER TABLE tokens DROP FOREIGN KEY tokens_ibfk_1,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- UPDATE dbMetadata SET value = '24' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
The migration removing these constraints did not stick in production, so we're reverting it here in code to keep things consistent.

Connects to https://github.com/mozilla/fxa-auth-server/issues/2695